### PR TITLE
Feat/startup check

### DIFF
--- a/spotify
+++ b/spotify
@@ -55,6 +55,11 @@ showHelp () {
 
 if [ $# = 0 ]; then
     showHelp;
+else
+    if [ $(osascript -e "application \"Spotify\" is running") = "false" ]; then
+        osascript -e "tell application \"Spotify\" to activate"
+        sleep 2
+    fi
 fi
 
 while [ $# -gt 0 ]; do

--- a/spotify
+++ b/spotify
@@ -53,6 +53,13 @@ showHelp () {
     echo "  toggle repeat                   # Toggle repeat playback mode.";
 }
 
+fancyEcho(){
+    bold=$(tput bold);
+    green=$(tput setaf 2);
+    reset=$(tput sgr0);
+    echo $bold$green$1$reset;
+}
+
 if [ $# = 0 ]; then
     showHelp;
 else
@@ -64,9 +71,6 @@ fi
 
 while [ $# -gt 0 ]; do
     arg=$1;
-    bold=$(tput bold);
-    green=$(tput setaf 2);
-    reset=$(tput sgr0);
 
     case $arg in
         "play"    )
@@ -81,7 +85,7 @@ while [ $# -gt 0 ]; do
                     _args=${array[@]:2:$len};
                     Q=$_args;
 
-                    echo $bold$green"Searching albums for: $Q";
+                    fancyEcho "Searching albums for: $Q";
 
                     SPTFY_URI=$( \
                         curl -s -G "https://api.spotify.com/v1/search" --data-urlencode "q=$Q" -d "type=album&limit=1&offset=0" -H "Accept: application/json" \
@@ -92,7 +96,7 @@ while [ $# -gt 0 ]; do
                     _args=${array[@]:2:$len};
                     Q=$_args;
 
-                    echo $bold$green"Searching artists for: $Q";
+                    fancyEcho "Searching artists for: $Q";
 
                     SPTFY_URI=$( \
                         curl -s -G "https://api.spotify.com/v1/search" --data-urlencode "q=$Q" -d "type=artist&limit=1&offset=0" -H "Accept: application/json" \
@@ -103,7 +107,7 @@ while [ $# -gt 0 ]; do
                     _args=${array[@]:2:$len};
                     Q=$_args;
 
-                    echo $bold$green"Searching playlists for: $Q";
+                    fancyEcho "Searching playlists for: $Q";
 
                     results=$( \
                         curl -s -G "https://api.spotify.com/v1/search" --data-urlencode "q=$Q" -d "type=playlist&limit=10&offset=0" -H "Accept: application/json" \
@@ -130,7 +134,7 @@ while [ $# -gt 0 ]; do
                     fi
                     Q=$_args;
 
-                    echo $bold$green"Searching tracks for: $Q";
+                    fancyEcho "Searching tracks for: $Q";
 
                     SPTFY_URI=$( \
                         curl -s -G "https://api.spotify.com/v1/search" --data-urlencode "q=$Q" -d "type=track&limit=1&offset=0" -H "Accept: application/json" \
@@ -139,36 +143,35 @@ while [ $# -gt 0 ]; do
                 fi
 
                 if [ "$SPTFY_URI" != "" ]; then
-                    echo $bold$green"Playing ($Q Search) -> Spotify URL: $SPTFY_URI";
+                    fancyEcho "Playing ($Q Search) -> Spotify URL: $SPTFY_URI";
 
                     osascript -e "tell application \"Spotify\" to play track \"$SPTFY_URI\"";
 
                 else
-                    echo $bold$green"No results when searching for $Q";
-
+                    fancyEcho "No results when searching for $Q";
                 fi
 
             else
 
                 # play is the only param
-                echo $bold$green"Playing Spotify.";
+                fancyEcho "Playing Spotify.";
                 osascript -e 'tell application "Spotify" to play';
             fi
             break ;;
 
-        "pause"    ) echo $bold$green"Pausing Spotify.";
+        "pause"    ) fancyEcho "Pausing Spotify.";
             osascript -e 'tell application "Spotify" to pause';
             break ;;
 
-        "quit"    ) echo $bold$green"Quitting Spotify.";
+        "quit"    ) fancyEcho "Quitting Spotify.";
             osascript -e 'tell application "Spotify" to quit';
             exit 1 ;;
 
-        "next"    ) echo $bold$green"Going to next track." ;
+        "next"    ) fancyEcho "Going to next track." ;
             osascript -e 'tell application "Spotify" to next track';
             break ;;
 
-        "prev"    ) echo $bold$green"Going to previous track.";
+        "prev"    ) fancyEcho "Going to previous track.";
             osascript -e 'tell application "Spotify" to previous track';
             break ;;
 
@@ -184,7 +187,7 @@ while [ $# -gt 0 ]; do
               text="to $2";
             fi
 
-            echo $bold$green"Changing Spotify volume level $text.";
+            fancyEcho "Changing Spotify volume level $text.";
             osascript -e "tell application \"Spotify\" to set sound volume to $newvol";
             break ;;
 
@@ -192,17 +195,17 @@ while [ $# -gt 0 ]; do
             if [ $2 = "shuffle" ]; then
                 osascript -e "tell application \"Spotify\" to set shuffling to not shuffling";
                 curr=`osascript -e 'tell application "Spotify" to shuffling'`;
-                echo $bold$green"Spotify shuffling set to $curr";
+                fancyEcho "Spotify shuffling set to $curr";
             elif [ $2 = "repeat" ]; then
                 osascript -e "tell application \"Spotify\" to set repeating to not repeating";
                 curr=`osascript -e 'tell application "Spotify" to repeating'`;
-                echo $bold$green"Spotify repeating set to $curr";
+                fancyEcho "Spotify repeating set to $curr";
             fi
             break ;;
 
         "status" )
             state=`osascript -e 'tell application "Spotify" to player state as string'`;
-            echo $bold$green"Spotify is currently $state.";
+            fancyEcho "Spotify is currently $state.";
             if [ $state = "playing" ]; then
                 artist=`osascript -e 'tell application "Spotify" to artist of current track as string'`;
                 album=`osascript -e 'tell application "Spotify" to album of current track as string'`;
@@ -217,12 +220,12 @@ while [ $# -gt 0 ]; do
             remove='spotify:track:'
             url=${url#$remove}
             url="http://open.spotify.com/track/$url"
-            echo $bold$green"Share URL: $url";
+            fancyEcho "Share URL: $url";
             echo "$url" | pbcopy
             break;;
 
         "pos"   )
-            echo $bold$green"Adjusting Spotify play position."
+            fancyEcho "Adjusting Spotify play position."
             osascript -e "tell application \"Spotify\" to set player position to $2";
             break;;
 

--- a/spotify
+++ b/spotify
@@ -53,7 +53,7 @@ showHelp () {
     echo "  toggle repeat                   # Toggle repeat playback mode.";
 }
 
-fancyEcho(){
+cecho(){
     bold=$(tput bold);
     green=$(tput setaf 2);
     reset=$(tput sgr0);
@@ -85,7 +85,7 @@ while [ $# -gt 0 ]; do
                     _args=${array[@]:2:$len};
                     Q=$_args;
 
-                    fancyEcho "Searching albums for: $Q";
+                    cecho "Searching albums for: $Q";
 
                     SPTFY_URI=$( \
                         curl -s -G "https://api.spotify.com/v1/search" --data-urlencode "q=$Q" -d "type=album&limit=1&offset=0" -H "Accept: application/json" \
@@ -96,7 +96,7 @@ while [ $# -gt 0 ]; do
                     _args=${array[@]:2:$len};
                     Q=$_args;
 
-                    fancyEcho "Searching artists for: $Q";
+                    cecho "Searching artists for: $Q";
 
                     SPTFY_URI=$( \
                         curl -s -G "https://api.spotify.com/v1/search" --data-urlencode "q=$Q" -d "type=artist&limit=1&offset=0" -H "Accept: application/json" \
@@ -107,7 +107,7 @@ while [ $# -gt 0 ]; do
                     _args=${array[@]:2:$len};
                     Q=$_args;
 
-                    fancyEcho "Searching playlists for: $Q";
+                    cecho "Searching playlists for: $Q";
 
                     results=$( \
                         curl -s -G "https://api.spotify.com/v1/search" --data-urlencode "q=$Q" -d "type=playlist&limit=10&offset=0" -H "Accept: application/json" \
@@ -134,7 +134,7 @@ while [ $# -gt 0 ]; do
                     fi
                     Q=$_args;
 
-                    fancyEcho "Searching tracks for: $Q";
+                    cecho "Searching tracks for: $Q";
 
                     SPTFY_URI=$( \
                         curl -s -G "https://api.spotify.com/v1/search" --data-urlencode "q=$Q" -d "type=track&limit=1&offset=0" -H "Accept: application/json" \
@@ -143,35 +143,35 @@ while [ $# -gt 0 ]; do
                 fi
 
                 if [ "$SPTFY_URI" != "" ]; then
-                    fancyEcho "Playing ($Q Search) -> Spotify URL: $SPTFY_URI";
+                    cecho "Playing ($Q Search) -> Spotify URL: $SPTFY_URI";
 
                     osascript -e "tell application \"Spotify\" to play track \"$SPTFY_URI\"";
 
                 else
-                    fancyEcho "No results when searching for $Q";
+                    cecho "No results when searching for $Q";
                 fi
 
             else
 
                 # play is the only param
-                fancyEcho "Playing Spotify.";
+                cecho "Playing Spotify.";
                 osascript -e 'tell application "Spotify" to play';
             fi
             break ;;
 
-        "pause"    ) fancyEcho "Pausing Spotify.";
+        "pause"    ) cecho "Pausing Spotify.";
             osascript -e 'tell application "Spotify" to pause';
             break ;;
 
-        "quit"    ) fancyEcho "Quitting Spotify.";
+        "quit"    ) cecho "Quitting Spotify.";
             osascript -e 'tell application "Spotify" to quit';
             exit 1 ;;
 
-        "next"    ) fancyEcho "Going to next track." ;
+        "next"    ) cecho "Going to next track." ;
             osascript -e 'tell application "Spotify" to next track';
             break ;;
 
-        "prev"    ) fancyEcho "Going to previous track.";
+        "prev"    ) cecho "Going to previous track.";
             osascript -e 'tell application "Spotify" to previous track';
             break ;;
 
@@ -187,7 +187,7 @@ while [ $# -gt 0 ]; do
               text="to $2";
             fi
 
-            fancyEcho "Changing Spotify volume level $text.";
+            cecho "Changing Spotify volume level $text.";
             osascript -e "tell application \"Spotify\" to set sound volume to $newvol";
             break ;;
 
@@ -195,17 +195,17 @@ while [ $# -gt 0 ]; do
             if [ $2 = "shuffle" ]; then
                 osascript -e "tell application \"Spotify\" to set shuffling to not shuffling";
                 curr=`osascript -e 'tell application "Spotify" to shuffling'`;
-                fancyEcho "Spotify shuffling set to $curr";
+                cecho "Spotify shuffling set to $curr";
             elif [ $2 = "repeat" ]; then
                 osascript -e "tell application \"Spotify\" to set repeating to not repeating";
                 curr=`osascript -e 'tell application "Spotify" to repeating'`;
-                fancyEcho "Spotify repeating set to $curr";
+                cecho "Spotify repeating set to $curr";
             fi
             break ;;
 
         "status" )
             state=`osascript -e 'tell application "Spotify" to player state as string'`;
-            fancyEcho "Spotify is currently $state.";
+            cecho "Spotify is currently $state.";
             if [ $state = "playing" ]; then
                 artist=`osascript -e 'tell application "Spotify" to artist of current track as string'`;
                 album=`osascript -e 'tell application "Spotify" to album of current track as string'`;
@@ -220,12 +220,12 @@ while [ $# -gt 0 ]; do
             remove='spotify:track:'
             url=${url#$remove}
             url="http://open.spotify.com/track/$url"
-            fancyEcho "Share URL: $url";
+            cecho "Share URL: $url";
             echo "$url" | pbcopy
             break;;
 
         "pos"   )
-            fancyEcho "Adjusting Spotify play position."
+            cecho "Adjusting Spotify play position."
             osascript -e "tell application \"Spotify\" to set player position to $2";
             break;;
 


### PR DESCRIPTION
Added check to run spotify if not running. I'm not super proud of the sleep statement but It's far the easiest way to get the right behaviour. 
Basically spotify doesn't accept any command until is fully loaded so it would't work without the sleep. A proper solution would be insert some check over the app state.
Also moved the fancy green-bold output creation to a function. Reset added to cleanup bash font settings after the output is completed. 