### PR TITLE
Safe parameter addressing

### DIFF
--- a/spotify
+++ b/spotify
@@ -80,7 +80,7 @@ while [ $# -gt 0 ]; do
                 len=${#array[@]};
                 SPTFY_URI="";
 
-                if [ $2 = "album" ]; then
+                if [ "$2" = "album" ]; then
                     _args=${array[@]:2:$len};
                     Q=$_args;
 
@@ -91,7 +91,7 @@ while [ $# -gt 0 ]; do
                         | grep -E -o "spotify:album:[a-zA-Z0-9]+" -m 1 \
                     )
 
-                elif [ $2 = "artist" ]; then
+                elif [ "$2" = "artist" ]; then
                     _args=${array[@]:2:$len};
                     Q=$_args;
 
@@ -102,7 +102,7 @@ while [ $# -gt 0 ]; do
                         | grep -E -o "spotify:artist:[a-zA-Z0-9]+" -m 1 \
                     )
 
-                elif [ $2 = "list" ]; then
+                elif [ "$2" = "list" ]; then
                     _args=${array[@]:2:$len};
                     Q=$_args;
 
@@ -126,7 +126,7 @@ while [ $# -gt 0 ]; do
                     fi
 
                 else
-                    if [ $2 = "track" ]; then
+                    if [ "$2" = "track" ]; then
                         _args=${array[@]:2:$len};
                     else
                         _args=${array[@]:1:$len};
@@ -184,9 +184,9 @@ while [ $# -gt 0 ]; do
         "vol"    )
             vol=`osascript -e 'tell application "Spotify" to sound volume as integer'`;
             text=$2;
-            if [ $2 = "up" ]; then
+            if [ "$2" = "up" ]; then
                 newvol=$(( vol+10 ));
-            elif [ $2 = "down" ]; then
+            elif [ "$2" = "down" ]; then
                 newvol=$(( vol-10 ));
             elif [ $2 -gt 0 ]; then
               newvol=$2;
@@ -198,11 +198,11 @@ while [ $# -gt 0 ]; do
             break ;;
 
         "toggle"  )
-            if [ $2 = "shuffle" ]; then
+            if [ "$2" = "shuffle" ]; then
                 osascript -e "tell application \"Spotify\" to set shuffling to not shuffling";
                 curr=`osascript -e 'tell application "Spotify" to shuffling'`;
                 cecho "Spotify shuffling set to $curr";
-            elif [ $2 = "repeat" ]; then
+            elif [ "$2" = "repeat" ]; then
                 osascript -e "tell application \"Spotify\" to set repeating to not repeating";
                 curr=`osascript -e 'tell application "Spotify" to repeating'`;
                 cecho "Spotify repeating set to $curr";


### PR DESCRIPTION
It wasn’t possible to run the script inside another script when the second parameter did contain white spaces.

