### PR TITLE
share: don't copy a trailing newline

### DIFF
--- a/spotify
+++ b/spotify
@@ -262,7 +262,7 @@ while [ $# -gt 0 ]; do
             url=${url#$remove}
             url="http://open.spotify.com/track/$url"
             cecho "Share URL: $url";
-            echo "$url" | pbcopy
+            echo -n "$url" | pbcopy
             break;;
 
         "pos"   )


### PR DESCRIPTION
`echo` adds a newline after the URL so the clipboard then contains `<url>\n` instead of `<url>`. `echo -n` solves this.