### PR TITLE
Fixed volume bugs reported in Issue #35

### DIFF
--- a/spotify
+++ b/spotify
@@ -195,21 +195,24 @@ while [ $# -gt 0 ]; do
             elif [ "$2" = "up" ]; then
                 if [ $vol -le 90 ]; then
                     newvol=$(( vol+10 ));
+                    cecho "Increasing Spotify volume to $newvol.";
                 else
                     newvol=100;
+                    cecho "Spotify volume level is at max.";
                 fi
             elif [ "$2" = "down" ]; then
                 if [ $vol -ge 10 ]; then
                     newvol=$(( vol-10 ));
+                    cecho "Reducing Spotify volume to $newvol.";
                 else
                     newvol=0;
+                    cecho "Spotify volume level is at min.";
                 fi
             elif [ $2 -gt 0 ]; then
                 newvol=$2;
                 text="to $2";
             fi
 
-            cecho "Changing Spotify volume level $text.";
             osascript -e "tell application \"Spotify\" to set sound volume to $newvol";
             break ;;
 

--- a/spotify
+++ b/spotify
@@ -189,12 +189,9 @@ while [ $# -gt 0 ]; do
         "vol"    )
             vol=`osascript -e 'tell application "Spotify" to sound volume as integer'`;
             text=$2;
-            if [ "$2" = "show" ]; then
+            if [[ "$2" = "show" || "$2" = "" ]]; then
                 cecho "Current Spotify volume level is $vol.";
                 break ;
-            elif [ "$2" = "" ]; then
-                cecho "Current Spotify volume level is $vol.";
-                break;
             elif [ "$2" = "up" ]; then
                 if [ $vol -le 90 ]; then
                     newvol=$(( vol+10 ));

--- a/spotify
+++ b/spotify
@@ -192,13 +192,24 @@ while [ $# -gt 0 ]; do
             if [ "$2" = "show" ]; then
                 cecho "Current Spotify volume level is $vol.";
                 break ;
+            elif [ "$2" = "" ]; then
+                cecho "Current Spotify volume level is $vol.";
+                break;
             elif [ "$2" = "up" ]; then
-                newvol=$(( vol+10 ));
+                if [ $vol -le 90 ]; then
+                    newvol=$(( vol+10 ));
+                else
+                    newvol=100;
+                fi
             elif [ "$2" = "down" ]; then
-                newvol=$(( vol-10 ));
+                if [ $vol -ge 10 ]; then
+                    newvol=$(( vol-10 ));
+                else
+                    newvol=0;
+                fi
             elif [ $2 -gt 0 ]; then
-              newvol=$2;
-              text="to $2";
+                newvol=$2;
+                text="to $2";
             fi
 
             cecho "Changing Spotify volume level $text.";
@@ -222,7 +233,7 @@ while [ $# -gt 0 ]; do
             break ;;
 
         "info" )
-            info=`osascript -e 'tell application "Spotify" 
+            info=`osascript -e 'tell application "Spotify"
                 set tM to round (duration of current track / 60) rounding down
                 set tS to duration of current track mod 60
                 set pos to player position as text
@@ -236,7 +247,7 @@ while [ $# -gt 0 ]; do
                 set info to info & "\nAlbum:          " & album of current track
                 set info to info & "\nSeconds:        " & duration of current track
                 set info to info & "\nSeconds played: " & pos
-                set info to info & "\nDuration:       " & mytime 
+                set info to info & "\nDuration:       " & mytime
                 set info to info & "\nNow at:         " & nowAt
                 set info to info & "\nPlayed Count:   " & played count of current track
                 set info to info & "\nTrack Number:   " & track number of current track


### PR DESCRIPTION
Some nice logic to fix the bugs caused by overflowing above 100 (and, turns out, below 0) for the volume, as reported by @LucaPipolo in Issue #35. While I was doing that I noticed that `spotify vol` crashed, which isn't that great, so I set `spotify vol` as an alias of `spotify vol show`. I kind of feel like we could remove `spotify vol show` now, but that's your call @hnarayanan.

Also took the time to fix some minor whitespace stuff.