### PR TITLE
Fixed Line Lengths in Help

### DIFF
--- a/spotify
+++ b/spotify
@@ -40,17 +40,18 @@ showHelp () {
     echo;
     echo "  next                         # Skips to the next song in a playlist.";
     echo "  prev                         # Returns to the previous song in a playlist.";
-    echo "  pos [time]                   # Jump to a specific time (in seconds) in the current song.";
+    echo "  pos [time]                   # Jump to a specific time (in seconds) in the"
+    echo "                               # current song.";
     echo "  pause                        # Pauses Spotify playback.";
     echo "  quit                         # Stops playback and quits Spotify.";
     echo;
     echo "  vol up                       # Increases the volume by 10%.";
     echo "  vol down                     # Decreases the volume by 10%.";
     echo "  vol [amount]                 # Sets the volume to an amount between 0 and 100.";
-    echo "  vol show                     # Shows the current Spotify volume between 0 and 100.";
+    echo "  vol show                     # The current Spotify volume from 0 and 100.";
     echo;
-    echo "  status                       # Shows the play status, including the current song details.";
-    echo "  share                        # Shows and copies the current song URL to the clipboard for sharing."
+    echo "  status                       # The play status, including the current song.";
+    echo "  share                        # Copies the current song URL to the clipboard."
     echo;
     echo "  toggle shuffle               # Toggle shuffle playback mode.";
     echo "  toggle repeat                # Toggle repeat playback mode.";

--- a/spotify
+++ b/spotify
@@ -40,8 +40,7 @@ showHelp () {
     echo;
     echo "  next                         # Skips to the next song in a playlist.";
     echo "  prev                         # Returns to the previous song in a playlist.";
-    echo "  pos [time]                   # Jump to a specific time (in seconds) in the"
-    echo "                               # current song.";
+    echo "  pos [time]                   # Jump to a time (in secs) in the current song.";
     echo "  pause                        # Pauses Spotify playback.";
     echo "  quit                         # Stops playback and quits Spotify.";
     echo;


### PR DESCRIPTION
The line lengths in 'Help' were too long for a standard 80 character wide window. I've updated them to fit within the standard width. Here's a before:

<img width="762" alt="screen shot 2016-06-15 at 1 47 42 pm" src="https://cloud.githubusercontent.com/assets/1939143/16080466/e959fc7c-3300-11e6-8bf9-5ab94c58aa3e.png">

...and here's an after:

<img width="762" alt="screen shot 2016-06-15 at 1 56 36 pm" src="https://cloud.githubusercontent.com/assets/1939143/16080484/fd193a66-3300-11e6-97bf-4d273aaf3343.png">

Just a quick fix, but it looks better now!