### PR TITLE
Be lenient if locale uses comma as decimal sep

### DIFF
--- a/spotify
+++ b/spotify
@@ -72,7 +72,7 @@ showStatus () {
         track=`osascript -e 'tell application "Spotify" to name of current track as string'`;
         duration=`osascript -e 'tell application "Spotify" to duration of current track as string'`;
         duration=$(echo "scale=2; $duration / 60 / 1000" | bc);
-        position=`osascript -e 'tell application "Spotify" to player position as string'`;
+        position=`osascript -e 'tell application "Spotify" to player position as string' | tr ',' '.'`;
         position=$(echo "scale=2; $position / 60" | bc | awk '{printf "%0.2f", $0}');
 
         echo -e $reset"Artist: $artist\nAlbum: $album\nTrack: $track \nPosition: $position / $duration";


### PR DESCRIPTION
 On certain locales player position is returned with a comma instead of a dot, which throws off `bc`