### PR TITLE
Correcting Styles and some minor bugs

### DIFF
--- a/spotify
+++ b/spotify
@@ -76,7 +76,7 @@ showStatus () {
         position=$(osascript -e 'tell application "Spotify" to player position as string' | tr ',' '.');
         position=$(echo "scale=2; $position / 60" | bc | awk '{printf "%0.2f", $0}');
 
-        echo -e "$reset""Artist: $artist\nAlbum: $album\nTrack: $track \nPosition: $position / $duration";
+        echo "$reset""Artist: $artist\nAlbum: $album\nTrack: $track \nPosition: $position / $duration";
     fi
 }
 

--- a/spotify
+++ b/spotify
@@ -50,7 +50,8 @@ showHelp () {
     echo "  vol show                     # Shows the current Spotify volume.";
     echo;
     echo "  status                       # Shows the current player status.";
-    echo "  share                        # Copies the current song URL to the clipboard."
+    echo "  share                        # Copies the current song URL to the clipboard.";
+    echo "  info                         # Shows Full Information about song that is playing.";
     echo;
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";

--- a/spotify
+++ b/spotify
@@ -208,7 +208,7 @@ while [ $# -gt 0 ]; do
                     newvol=0;
                     cecho "Spotify volume level is at min.";
                 fi
-            elif [ $2 -gt 0 ]; then
+            elif [ $2 -ge 0 ]; then
                 newvol=$2;
                 text="to $2";
             fi

--- a/spotify
+++ b/spotify
@@ -76,7 +76,7 @@ showStatus () {
         position=$(osascript -e 'tell application "Spotify" to player position as string' | tr ',' '.');
         position=$(echo "scale=2; $position / 60" | bc | awk '{printf "%0.2f", $0}');
 
-        echo "$reset""Artist: $artist\nAlbum: $album\nTrack: $track \nPosition: $position / $duration";
+      printf "$reset""Artist: %s\nAlbum: %s\nTrack: %s \nPosition: %s / %s" "$artist" "$album" "$track" "$position" "$duration";
     fi
 }
 

--- a/spotify
+++ b/spotify
@@ -28,7 +28,7 @@
 showHelp () {
     echo "Usage:";
     echo;
-    echo "  `basename $0` <command>";
+    echo "  $(basename "$0") <command>";
     echo;
     echo "Commands:";
     echo;
@@ -60,29 +60,29 @@ cecho(){
     bold=$(tput bold);
     green=$(tput setaf 2);
     reset=$(tput sgr0);
-    echo $bold$green"$1"$reset;
+    echo "$bold$green$1$reset";
 }
 
 showStatus () {
-    state=`osascript -e 'tell application "Spotify" to player state as string'`;
+    state=$(osascript -e 'tell application "Spotify" to player state as string');
     cecho "Spotify is currently $state.";
-    if [ $state = "playing" ]; then
-        artist=`osascript -e 'tell application "Spotify" to artist of current track as string'`;
-        album=`osascript -e 'tell application "Spotify" to album of current track as string'`;
-        track=`osascript -e 'tell application "Spotify" to name of current track as string'`;
-        duration=`osascript -e 'tell application "Spotify" to duration of current track as string'`;
+    if [ "$state" = "playing" ]; then
+        artist=$(osascript -e 'tell application "Spotify" to artist of current track as string');
+        album=$(osascript -e 'tell application "Spotify" to album of current track as string');
+        track=$(osascript -e 'tell application "Spotify" to name of current track as string');
+        duration=$(osascript -e 'tell application "Spotify" to duration of current track as string');
         duration=$(echo "scale=2; $duration / 60 / 1000" | bc);
-        position=`osascript -e 'tell application "Spotify" to player position as string' | tr ',' '.'`;
+        position=$(osascript -e 'tell application "Spotify" to player position as string' | tr ',' '.');
         position=$(echo "scale=2; $position / 60" | bc | awk '{printf "%0.2f", $0}');
 
-        echo -e $reset"Artist: $artist\nAlbum: $album\nTrack: $track \nPosition: $position / $duration";
+        echo -e "$reset""Artist: $artist\nAlbum: $album\nTrack: $track \nPosition: $position / $duration";
     fi
 }
 
 if [ $# = 0 ]; then
     showHelp;
 else
-    if [ $(osascript -e 'application "Spotify" is running') = "false" ]; then
+    if [ "$(osascript -e 'application "Spotify" is running')" = "false" ]; then
         osascript -e 'tell application "Spotify" to activate'
         sleep 2
     fi
@@ -113,7 +113,7 @@ while [ $# -gt 0 ]; do
 
                 case $2 in
                     "list"  )
-                        _args=${array[@]:2:$len};
+                        _args=${array[*]:2:$len};
                         Q=$_args;
 
                         cecho "Searching playlists for: $Q";
@@ -128,7 +128,7 @@ while [ $# -gt 0 ]; do
                         )
 
                         if [ "$count" -gt 0 ]; then
-                            random=$(( $RANDOM % $count));
+                            random=$(( RANDOM % count));
 
                             SPOTIFY_PLAY_URI=$( \
                                 echo "$results" | awk -v random="$random" '/spotify:user:[a-zA-Z0-9]+:playlist:[a-zA-Z0-9]+/{i++}i==random{print; exit}' \
@@ -136,16 +136,16 @@ while [ $# -gt 0 ]; do
                         fi;;
 
                     "album" | "artist" | "track"    )
-                        _args=${array[@]:2:$len};
-                        searchAndPlay $2 "$_args";;
+                        _args=${array[*]:2:$len};
+                        searchAndPlay "$2" "$_args";;
 
                     *   )
-                        _args=${array[@]:1:$len};
+                        _args=${array[*]:1:$len};
                         searchAndPlay track "$_args";;
                 esac
 
                 if [ "$SPOTIFY_PLAY_URI" != "" ]; then
-                    cecho "Playing ($Q Search) -> Spotify URL: $SPOTIFY_PLAY_URI";
+                    cecho "Playing ($Q Search) -> Spotify URL: $";
 
                     osascript -e "tell application \"Spotify\" to play track \"$SPOTIFY_PLAY_URI\"";
 
@@ -162,8 +162,8 @@ while [ $# -gt 0 ]; do
             break ;;
 
         "pause"    )
-            state=`osascript -e 'tell application "Spotify" to player state as string'`;
-            if [ $state = "playing" ]; then
+            state=$(osascript -e 'tell application "Spotify" to player state as string');
+            if [ "$state" = "playing" ]; then
               cecho "Pausing Spotify.";
             else
               cecho "Playing Spotify.";
@@ -187,13 +187,12 @@ while [ $# -gt 0 ]; do
             break ;;
 
         "vol"    )
-            vol=`osascript -e 'tell application "Spotify" to sound volume as integer'`;
-            text=$2;
+            vol=$(osascript -e 'tell application "Spotify" to sound volume as integer');
             if [[ "$2" = "show" || "$2" = "" ]]; then
                 cecho "Current Spotify volume level is $vol.";
                 break ;
             elif [ "$2" = "up" ]; then
-                if [ $vol -le 90 ]; then
+                if [ "$vol" -le 90 ]; then
                     newvol=$(( vol+10 ));
                     cecho "Increasing Spotify volume to $newvol.";
                 else
@@ -201,16 +200,15 @@ while [ $# -gt 0 ]; do
                     cecho "Spotify volume level is at max.";
                 fi
             elif [ "$2" = "down" ]; then
-                if [ $vol -ge 10 ]; then
+                if [ "$vol" -ge 10 ]; then
                     newvol=$(( vol-10 ));
                     cecho "Reducing Spotify volume to $newvol.";
                 else
                     newvol=0;
                     cecho "Spotify volume level is at min.";
                 fi
-            elif [ $2 -ge 0 ]; then
+            elif [ "$2" -ge 0 ]; then
                 newvol=$2;
-                text="to $2";
             fi
 
             osascript -e "tell application \"Spotify\" to set sound volume to $newvol";
@@ -219,11 +217,11 @@ while [ $# -gt 0 ]; do
         "toggle"  )
             if [ "$2" = "shuffle" ]; then
                 osascript -e 'tell application "Spotify" to set shuffling to not shuffling';
-                curr=`osascript -e 'tell application "Spotify" to shuffling'`;
+                curr=$(osascript -e 'tell application "Spotify" to shuffling');
                 cecho "Spotify shuffling set to $curr";
             elif [ "$2" = "repeat" ]; then
                 osascript -e 'tell application "Spotify" to set repeating to not repeating';
-                curr=`osascript -e 'tell application "Spotify" to repeating'`;
+                curr=$(osascript -e 'tell application "Spotify" to repeating');
                 cecho "Spotify repeating set to $curr";
             fi
             break ;;
@@ -233,7 +231,7 @@ while [ $# -gt 0 ]; do
             break ;;
 
         "info" )
-            info=`osascript -e 'tell application "Spotify"
+            info=$(osascript -e 'tell application "Spotify"
                 set tM to round (duration of current track / 60) rounding down
                 set tS to duration of current track mod 60
                 set pos to player position as text
@@ -260,12 +258,12 @@ while [ $# -gt 0 ]; do
                 set info to info & "\nShuffle:        " & shuffling
                 set info to info & "\nRepeating:      " & repeating
             end tell
-            return info'`
+            return info')
             cecho "$info";
             break ;;
 
         "share"     )
-            url=`osascript -e 'tell application "Spotify" to spotify url of current track'`;
+            url=$(osascript -e 'tell application "Spotify" to spotify url of current track');
             remove='spotify:track:'
             url=${url#$remove}
             url="http://open.spotify.com/track/$url"


### PR DESCRIPTION
first volume can't set to 0 fixed
and then some edit to improve code style :
- $/${} was unnecessary on arithmetic variables.
- text in vol appears unused.
- Assigning an array to a string so use \* instead of @ to concatenate.
- Double quote to prevent globbing and word splitting.
- Use $(..) instead of legacy `..`
