### PR TITLE
play by uri (new)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ spotify play [song name]          Finds a song by name and plays it.
 spotify play album [album name]   Finds an album by name and plays it.
 spotify play artist [artist name] Finds an artist by name and plays it.
 spotify play list [playlist name] Finds a playlist by name and plays it.
+spotify play uri [uri]            Play songs from specific uri.
 
 spotify next                      Skips to the next song in a playlist.
 spotify prev                      Returns to the previous song in a playlist.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ spotify vol [amount]              Sets the volume to an amount between 0 and 100
 spotify vol                       Shows the current volume.
 
 spotify status                    Shows the play status, including the current song details.
-spotify share                     Shows and copies the current song URL to the clipboard for sharing.
+
+spotify share                     Displays the current song's Spotify URL and URI.
+spotify share url 				  Displays the current song's Spotify URL and copies it to the clipboard.
+spotify share uri 				  Displays the current song's Spotify URI and copies it to the clipboard.
 
 spotify toggle shuffle            Toggles shuffle playback mode.
 spotify toggle repeat             Toggles repeat playback mode.

--- a/spotify
+++ b/spotify
@@ -139,13 +139,20 @@ while [ $# -gt 0 ]; do
                         _args=${array[@]:2:$len};
                         searchAndPlay $2 "$_args";;
 
+                    "uri"  )
+                        SPOTIFY_PLAY_URI=${array[@]:2:$len};;
+
                     *   )
                         _args=${array[@]:1:$len};
                         searchAndPlay track "$_args";;
                 esac
 
                 if [ "$SPOTIFY_PLAY_URI" != "" ]; then
-                    cecho "Playing ($Q Search) -> Spotify URL: $SPOTIFY_PLAY_URI";
+                    if [ "$2" = "uri" ]; then
+                        cecho "Playing Spotify URI: $SPOTIFY_PLAY_URI";
+                    else
+                        cecho "Playing ($Q Search) -> Spotify URI: $SPOTIFY_PLAY_URI";
+                    fi
 
                     osascript -e "tell application \"Spotify\" to play track \"$SPOTIFY_PLAY_URI\"";
 
@@ -269,9 +276,20 @@ while [ $# -gt 0 ]; do
             remove='spotify:track:'
             url=${uri#$remove}
             url="http://open.spotify.com/track/$url"
-            cecho "Share URL: $url";
-            cecho "Spotify URI: $uri";
-            echo -n "$url" | pbcopy
+
+            if [ "$2" = "" ]; then
+                cecho "Spotify URL: $url"
+                cecho "Spotify URI: $uri"
+                echo "To copy the URL or URI to your clipboard, use:"
+                echo "\`spotify share url\` or"
+                echo "\`spotify share uri\` respectively."
+            elif [ "$2" = "url" ]; then
+                cecho "Spotify URL: $url";
+                echo -n $url | pbcopy
+            elif [ "$2" = "uri" ]; then
+                cecho "Spotify URI: $uri";
+                echo -n $uri | pbcopy
+            fi
             break;;
 
         "pos"   )

--- a/spotify
+++ b/spotify
@@ -37,6 +37,7 @@ showHelp () {
     echo "  play album [album name]      # Finds an album by name and plays it.";
     echo "  play artist [artist name]    # Finds an artist by name and plays it.";
     echo "  play list [playlist name]    # Finds a playlist by name and plays it.";
+    echo "  play uri [uri]               # Play songs from specific uri.";
     echo;
     echo "  next                         # Skips to the next song in a playlist.";
     echo "  prev                         # Returns to the previous song in a playlist.";

--- a/spotify
+++ b/spotify
@@ -265,11 +265,12 @@ while [ $# -gt 0 ]; do
             break ;;
 
         "share"     )
-            url=`osascript -e 'tell application "Spotify" to spotify url of current track'`;
+            uri=`osascript -e 'tell application "Spotify" to spotify url of current track'`;
             remove='spotify:track:'
-            url=${url#$remove}
+            url=${uri#$remove}
             url="http://open.spotify.com/track/$url"
             cecho "Share URL: $url";
+            cecho "Spotify URI: $uri";
             echo -n "$url" | pbcopy
             break;;
 

--- a/spotify
+++ b/spotify
@@ -51,7 +51,10 @@ showHelp () {
     echo "  vol show                     # Shows the current Spotify volume.";
     echo;
     echo "  status                       # Shows the current player status.";
-    echo "  share                        # Copies the current song URL to the clipboard."
+    echo;
+    echo "  share                        # Displays the current song's Spotify URL and URI."
+    echo "  share url                    # Displays the current song's Spotify URL and copies it to the clipboard."
+    echo "  share uri                    # Displays the current song's Spotify URI and copies it to the clipboard."
     echo;
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";


### PR DESCRIPTION
Updated version of #27.

Adds the following stuff:

## `spotify play uri [uri]`

`spotify play uri` works as it did (I presume at some point) from #27. However, the output looks a bit different. Instead of
```
$ ./spotify play uri spotify:track:79BtIFYdWgo9FZiotlcNks
Playing (spotify:track:79BtIFYdWgo9FZiotlcNks Search) -> Spotify URL: spotify:track:1nmsQpJZroNYaq0DPdxsUZ
```

We now get
```
$ ./spotify play uri spotify:track:79BtIFYdWgo9FZiotlcNks
Playing Spotify URI: spotify:track:79BtIFYdWgo9FZiotlcNks
```

Which is shorter, doesn't give the URI twice, and IMO communicates meaning better as the `spotify play uri` command does not cause a search.

## `spotify share`

`spotify share` no longer just displays the URL and copies it to the clipboard. Now, it just displays the URL and URI.

We also have 2 new `spotify share` sub-commands:

1. `spotify share url` displays and copies the URL to the clipboard.
2. `spotify share uri` displays and copies the URI (surprise!) to the clipboard.


## Docs
I also updated the docs to reflect these changes (both the in command documentation/help text and the README).