### PR TITLE
fixes minutes and seconds for duration and position

### DIFF
--- a/spotify
+++ b/spotify
@@ -70,10 +70,28 @@ showStatus () {
         artist=`osascript -e 'tell application "Spotify" to artist of current track as string'`;
         album=`osascript -e 'tell application "Spotify" to album of current track as string'`;
         track=`osascript -e 'tell application "Spotify" to name of current track as string'`;
-        duration=`osascript -e 'tell application "Spotify" to duration of current track as string'`;
-        duration=$(echo "scale=2; $duration / 60 / 1000" | bc);
-        position=`osascript -e 'tell application "Spotify" to player position as string' | tr ',' '.'`;
-        position=$(echo "scale=2; $position / 60" | bc | awk '{printf "%0.2f", $0}');
+        duration=`osascript -e 'tell application "Spotify" 
+                set durSec to (duration of current track / 1000) as text
+                set tM to (round (durSec / 60) rounding down) as text
+                if length of ((durSec mod 60 div 1) as text) is greater than 1 then
+                    set tS to (durSec mod 60 div 1) as text
+                else
+                    set tS to ("0" & (durSec mod 60 div 1)) as text
+                end if
+                set myTime to tM as text & ":" & tS as text
+                end tell
+                return myTime'`;
+        position=`osascript -e 'tell application "Spotify" 
+                set pos to player position
+                set nM to (round (pos / 60) rounding down) as text
+                if length of ((round (pos mod 60) rounding down) as text) is greater than 1 then
+                    set nS to (round (pos mod 60) rounding down) as text
+                else
+                    set nS to ("0" & (round (pos mod 60) rounding down)) as text
+                end if
+                set nowAt to nM as text & ":" & nS as text
+                end tell
+                return nowAt'`;
 
         echo -e $reset"Artist: $artist\nAlbum: $album\nTrack: $track \nPosition: $position / $duration";
     fi
@@ -234,18 +252,27 @@ while [ $# -gt 0 ]; do
 
         "info" )
             info=`osascript -e 'tell application "Spotify"
-                set tM to round (duration of current track / 60) rounding down
-                set tS to duration of current track mod 60
-                set pos to player position as text
+                set durSec to (duration of current track / 1000)
+                set tM to (round (durSec / 60) rounding down) as text
+                if length of ((durSec mod 60 div 1) as text) is greater than 1 then
+                    set tS to (durSec mod 60 div 1) as text
+                else
+                    set tS to ("0" & (durSec mod 60 div 1)) as text
+                end if
                 set myTime to tM as text & "min " & tS as text & "s"
-                set nM to round (player position / 60) rounding down
-                set nS to round (player position mod 60) rounding down
+                set pos to player position
+                set nM to (round (pos / 60) rounding down) as text
+                if length of ((round (pos mod 60) rounding down) as text) is greater than 1 then
+                    set nS to (round (pos mod 60) rounding down) as text
+                else
+                    set nS to ("0" & (round (pos mod 60) rounding down)) as text
+                end if
                 set nowAt to nM as text & "min " & nS as text & "s"
                 set info to "" & "\nArtist:         " & artist of current track
                 set info to info & "\nTrack:          " & name of current track
                 set info to info & "\nAlbum Artist:   " & album artist of current track
                 set info to info & "\nAlbum:          " & album of current track
-                set info to info & "\nSeconds:        " & duration of current track
+                set info to info & "\nSeconds:        " & durSec
                 set info to info & "\nSeconds played: " & pos
                 set info to info & "\nDuration:       " & mytime
                 set info to info & "\nNow at:         " & nowAt


### PR DESCRIPTION
Fixes issue #42.

Issuing `spotify status` used to display **Position** in decimal notation rather than *mm:ss* like this:
```console
$ spotify status
Spotify is currently playing.
Artist: Fantomas
Album: Delirium Cordia
Track: Delirium Cordia
Position: 8.18 / 74.28
```
Now it is displayed in proper *mm:ss* notation:
```console
$ ./spotify status
Spotify is currently playing.
Artist: Fantomas
Album: Delirium Cordia
Track: Delirium Cordia
Position: 8:11 / 74:17
```

Likewise, issuing `spotify info` used to incorrectly display **Seconds** as milliseconds.  Also, **Duration** was in decimal notation, but missing the decimal so both *min* and *s* were wrong.
```console
$ spotify info

Artist:         Fantomas
Track:          Delirium Cordia
Album Artist:   Fantomas
Album:          Delirium Cordia
Seconds:        4457023
Seconds played: 938.352
Duration:       74283min 43s
Now at:         15min 38s
Played Count:   0
Track Number:   1
Popularity:     5
Id:             spotify:track:2Torj6I1odKY9AaquPScfW
Spotify URL:    spotify:track:2Torj6I1odKY9AaquPScfW
Artwork:        missing value
Player:         playing
Volume:         24
Shuffle:        true
Repeating:      false
```

Now **Seconds** is displayed properly as seconds and **Duration** is displayed properly as *min* and *s*:
```console
$ ./spotify info

Artist:         Fantomas
Track:          Delirium Cordia
Album Artist:   Fantomas
Album:          Delirium Cordia
Seconds:        4457.023
Seconds played: 938.466
Duration:       74min 17s
Now at:         15min 38s
Played Count:   0
Track Number:   1
Popularity:     5
Id:             spotify:track:2Torj6I1odKY9AaquPScfW
Spotify URL:    spotify:track:2Torj6I1odKY9AaquPScfW
Artwork:        missing value
Player:         playing
Volume:         24
Shuffle:        true
Repeating:      false
```

Pull accurately displays songs longer than an hour and left pads *seconds* if they aren't double digits, i.e. 1 vs 01.  I didn't bother left padding *minutes* since they were displayed as single digits previously.  Simple timing results didn't vary much from the original code *(time is calculated for 10 total runs of the command)*:
```console
# original spotify status
$ time for i in {1..10}; do spotify status; done
real	0m4.067s
user	0m1.818s
sys	0m1.340s
```
```console
# new spotify status
$ time for i in {1..10}; do ./spotify status; done
real	0m4.062s
user	0m1.819s
sys	0m1.292s
```
```console
# original spotify info
$ time for i in {1..10}; do spotify info; done
real	0m1.153s
user	0m0.546s
sys	0m0.386s
```
```console
# new spotify info
$ time for i in {1..10}; do ./spotify info; done
real	0m1.154s
user	0m0.549s
sys	0m0.382s
```