### PR TITLE
Fix Artwork: missing value

### DIFF
--- a/spotify
+++ b/spotify
@@ -254,7 +254,7 @@ while [ $# -gt 0 ]; do
                 set info to info & "\nPopularity:     " & popularity of current track
                 set info to info & "\nId:             " & id of current track
                 set info to info & "\nSpotify URL:    " & spotify url of current track
-                set info to info & "\nArtwork:        " & artwork of current track
+                set info to info & "\nArtwork:        " & artwork url of current track
                 set info to info & "\nPlayer:         " & player state
                 set info to info & "\nVolume:         " & sound volume
                 set info to info & "\nShuffle:        " & shuffling


### PR DESCRIPTION
I didn't create an issue for this, but it's a quick fix and thought I'd submit a pull request.  According to `/Applications/Spotify.app/Contents/Resources/Spotify.sdef`, the property `artwork` is described as *"The property is deprecated and will never be set. Use the 'artwork url' instead."*  This pull simply updates the script to use `artwork url` instead of `artwork`.  Currently using `artwork`:
```console
$ spotify info

Artist:         Fantomas
Track:          Page 5
Album Artist:   Fantomas
Album:          Fantomas
Seconds:        46000
Seconds played: 8.833999633789
Duration:       766min 40s
Now at:         0min 8s
Played Count:   0
Track Number:   5
Popularity:     6
Id:             spotify:track:6b6aEa9DxgwqbW0HaDk3Jg
Spotify URL:    spotify:track:6b6aEa9DxgwqbW0HaDk3Jg
Artwork:        missing value
Player:         paused
Volume:         24
Shuffle:        true
Repeating:      false
```
and with the updated `artwork url` property:
```console
$ ./spotify info

Artist:         Fantomas
Track:          Page 5
Album Artist:   Fantomas
Album:          Fantomas
Seconds:        46000
Seconds played: 8.833999633789
Duration:       766min 40s
Now at:         0min 8s
Played Count:   0
Track Number:   5
Popularity:     6
Id:             spotify:track:6b6aEa9DxgwqbW0HaDk3Jg
Spotify URL:    spotify:track:6b6aEa9DxgwqbW0HaDk3Jg
Artwork:        http://images.spotify.com/image/ac83b34b1e2b04a9a3cae53cc7ac168814a44089
Player:         paused
Volume:         24
Shuffle:        true
Repeating:      false
```