### PR TITLE
remove if statement that blocks status details if paused

### DIFF
--- a/spotify
+++ b/spotify
@@ -72,35 +72,33 @@ cecho(){
 showStatus () {
     state=`osascript -e 'tell application "Spotify" to player state as string'`;
     cecho "Spotify is currently $state.";
-    if [ $state = "playing" ]; then
-        artist=`osascript -e 'tell application "Spotify" to artist of current track as string'`;
-        album=`osascript -e 'tell application "Spotify" to album of current track as string'`;
-        track=`osascript -e 'tell application "Spotify" to name of current track as string'`;
-        duration=`osascript -e 'tell application "Spotify"
-                set durSec to (duration of current track / 1000) as text
-                set tM to (round (durSec / 60) rounding down) as text
-                if length of ((durSec mod 60 div 1) as text) is greater than 1 then
-                    set tS to (durSec mod 60 div 1) as text
-                else
-                    set tS to ("0" & (durSec mod 60 div 1)) as text
-                end if
-                set myTime to tM as text & ":" & tS as text
-                end tell
-                return myTime'`;
-        position=`osascript -e 'tell application "Spotify"
-                set pos to player position
-                set nM to (round (pos / 60) rounding down) as text
-                if length of ((round (pos mod 60) rounding down) as text) is greater than 1 then
-                    set nS to (round (pos mod 60) rounding down) as text
-                else
-                    set nS to ("0" & (round (pos mod 60) rounding down)) as text
-                end if
-                set nowAt to nM as text & ":" & nS as text
-                end tell
-                return nowAt'`;
+    artist=`osascript -e 'tell application "Spotify" to artist of current track as string'`;
+    album=`osascript -e 'tell application "Spotify" to album of current track as string'`;
+    track=`osascript -e 'tell application "Spotify" to name of current track as string'`;
+    duration=`osascript -e 'tell application "Spotify"
+            set durSec to (duration of current track / 1000) as text
+            set tM to (round (durSec / 60) rounding down) as text
+            if length of ((durSec mod 60 div 1) as text) is greater than 1 then
+                set tS to (durSec mod 60 div 1) as text
+            else
+                set tS to ("0" & (durSec mod 60 div 1)) as text
+            end if
+            set myTime to tM as text & ":" & tS as text
+            end tell
+            return myTime'`;
+    position=`osascript -e 'tell application "Spotify"
+            set pos to player position
+            set nM to (round (pos / 60) rounding down) as text
+            if length of ((round (pos mod 60) rounding down) as text) is greater than 1 then
+                set nS to (round (pos mod 60) rounding down) as text
+            else
+                set nS to ("0" & (round (pos mod 60) rounding down)) as text
+            end if
+            set nowAt to nM as text & ":" & nS as text
+            end tell
+            return nowAt'`;
 
-        echo -e $reset"Artist: $artist\nAlbum: $album\nTrack: $track \nPosition: $position / $duration";
-    fi
+    echo -e $reset"Artist: $artist\nAlbum: $album\nTrack: $track \nPosition: $position / $duration";
 }
 
 if [ $# = 0 ]; then


### PR DESCRIPTION
@ericmarkmartin had this little [gem](https://github.com/hnarayanan/shpotify/pull/43#issuecomment-243651184) as a comment in one if his recent pull requests.  Open to discussion, but I agree with him that it would be nice to see a status when running `spotify status` even if currently paused.

This pull request simply pulls the status logic out of the if statement.

**Original**
```console
$ spotify status
Spotify is currently paused.
```

**Improved**
```console
$ ./spotify status
Spotify is currently paused.
Artist: The Soul Lifters
Album: The World's Rarest Funk 45s
Track: Hot Funky And Sweaty
Position: 0:35 / 2:51
```