### PR TITLE
'spotify pause' - Toggle removed, now always pauses. 

### DIFF
--- a/spotify
+++ b/spotify
@@ -262,11 +262,11 @@ while [ $# -gt 0 ]; do
             state=`osascript -e 'tell application "Spotify" to player state as string'`;
             if [ $state = "playing" ]; then
               cecho "Pausing Spotify.";
+              osascript -e 'tell application "Spotify" to playpause';
             else
-              cecho "Playing Spotify.";
+              cecho "Spotify is already paused.";
             fi
 
-            osascript -e 'tell application "Spotify" to playpause';
             break ;;
 
         "quit"    ) cecho "Quitting Spotify.";


### PR DESCRIPTION
## References #85 - 'spotify pause' always sets pause state.

Toggle play/pause effect removed, now always activates pause state.