### PR TITLE
Fix `play list` not working

### DIFF
--- a/spotify
+++ b/spotify
@@ -190,7 +190,7 @@ while [ $# -gt 0 ]; do
                     type="$1"
                     Q="$2"
 
-                    getAccessToken
+                    getAccessToken;
 
                     cecho "Searching ${type}s for: $Q";
 
@@ -210,7 +210,7 @@ while [ $# -gt 0 ]; do
                         _args=${array[@]:2:$len};
                         Q=$_args;
 
-                        getAccessToken
+                        getAccessToken;
 
                         cecho "Searching playlists for: $Q";
 

--- a/spotify
+++ b/spotify
@@ -210,10 +210,12 @@ while [ $# -gt 0 ]; do
                         _args=${array[@]:2:$len};
                         Q=$_args;
 
+                        getAccessToken
+
                         cecho "Searching playlists for: $Q";
 
                         results=$( \
-                            curl -s -G $SPOTIFY_SEARCH_API --data-urlencode "q=$Q" -d "type=playlist&limit=10&offset=0" -H "Accept: application/json" \
+                            curl -s -G $SPOTIFY_SEARCH_API --data-urlencode "q=$Q" -d "type=playlist&limit=10&offset=0" -H "Accept: application/json" -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN}" \
                             | grep -E -o "spotify:user:[a-zA-Z0-9_]+:playlist:[a-zA-Z0-9]+" -m 10 \
                         )
 

--- a/spotify
+++ b/spotify
@@ -161,10 +161,7 @@ while [ $# -gt 0 ]; do
                 SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n");
                 SPOTIFY_PLAY_URI="";
 
-                searchAndPlay() {
-                    type="$1"
-                    Q="$2"
-
+                getAccessToken() {
                     cecho "Connecting to Spotify's API";
 
                     SPOTIFY_TOKEN_RESPONSE_DATA=$( \
@@ -187,6 +184,13 @@ while [ $# -gt 0 ]; do
                         | sed 's/"//g' \
                         | sed 's/,.*//g' \
                     )
+                }
+
+                searchAndPlay() {
+                    type="$1"
+                    Q="$2"
+
+                    getAccessToken
 
                     cecho "Searching ${type}s for: $Q";
 


### PR DESCRIPTION
Adds a missing authorization header to the API request that searches for the playlist.
Also moves getting an auth token into a separate function.
Fixes #90.