### PR TITLE
Update README and script with Spotify.app dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Twitter](https://twitter.com/copingbear) to learn about the other
 things I do.
 
 ## Installation
+Install the Spotify desktop application if you haven't already.
 
 ### Homebrew
 

--- a/spotify
+++ b/spotify
@@ -133,8 +133,13 @@ showStatus () {
 if [ $# = 0 ]; then
     showHelp;
 else
+	if [ ! -d /Application/Spotify.app ] && [ ! -d $HOME/Applications/Spotify.app ]; then
+		echo "The Spotify application must be installed."
+		exit 1
+	fi
+
     if [ $(osascript -e 'application "Spotify" is running') = "false" ]; then
-        osascript -e 'tell application "Spotify" to activate'
+        osascript -e 'tell application "Spotify" to activate' || exit 1
         sleep 2
     fi
 fi


### PR DESCRIPTION
* updated README to explicitly say the Spotify app is required
* updated `spotify` to exit gracefully and print help if Spotify.app is not installed (user or system-wide)
* updated `spotify` to exit gracefully if the first `osascript` command trying to activate Spotify.app fails (otherwise the script continues to run with obscure errors)