### PR TITLE
adding information about spotify-cli-linux project to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ reported](https://github.com/hnarayanan/shpotify/issues) and
 request](https://help.github.com/articles/using-pull-requests/). **Thank
 you!**
 
+## Linux version
+
+If you want to use command line interface to Spotify on Linux, please check [spotify-cli-linux](https://github.com/pwittchen/spotify-cli-linux) project.
+
 ## Copyright and license
 
 Copyright (c) 2012–2018 [Harish Narayanan](https://harishnarayanan.org).


### PR DESCRIPTION
Hi

I've already noticed in the issue #70 that you're not planning to support Linux in this project. Luckily, your project inspired me to create a Spotify CLI for Linux. It's available at https://github.com/pwittchen/spotify-cli-linux and I also linked your project there. In this PR I'm adding a link to the Linux version of the Spotify CLI to the `README.md` file. I hope someone will find it useful :).

Regards,
Piotr