### PR TITLE
Fixed environment variable name, causes script to crash when querying API

### DIFF
--- a/spotify
+++ b/spotify
@@ -173,7 +173,7 @@ while [ $# -gt 0 ]; do
                             -d "grant_type=client_credentials" \
                     )
                     if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
-                        cecho "Autorization failed, please check ${USER_CONFG_FILE}"
+                        cecho "Autorization failed, please check ${USER_CONFIG_FILE}"
                         cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
                         showAPIHelp
                         exit 1


### PR DESCRIPTION
The environment variable USER_CONFIG_FILE is mistyped, this fixes it. Fixes #108 