### PR TITLE
Update Spotify global installation path

### DIFF
--- a/spotify
+++ b/spotify
@@ -133,7 +133,7 @@ showStatus () {
 if [ $# = 0 ]; then
     showHelp;
 else
-	if [ ! -d /Application/Spotify.app ] && [ ! -d $HOME/Applications/Spotify.app ]; then
+	if [ ! -d /Applications/Spotify.app ] && [ ! -d $HOME/Applications/Spotify.app ]; then
 		echo "The Spotify application must be installed."
 		exit 1
 	fi


### PR DESCRIPTION
When Spotify is installed globally (i.e. not to $HOME/Applications) it is stored in `/Applications`, not `/Applications`.