### PR TITLE
Fix play list functionality

### DIFF
--- a/spotify
+++ b/spotify
@@ -234,18 +234,18 @@ while [ $# -gt 0 ]; do
 
                         results=$( \
                             curl -s -G $SPOTIFY_SEARCH_API --data-urlencode "q=$Q" -d "type=playlist&limit=10&offset=0" -H "Accept: application/json" -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN}" \
-                            | grep -E -o "spotify:user:[a-zA-Z0-9_]+:playlist:[a-zA-Z0-9]+" -m 10 \
+                            | grep -E -o "spotify:playlist:[a-zA-Z0-9]+" -m 10 \
                         )
 
                         count=$( \
-                            echo "$results" | grep -c "spotify:user" \
+                            echo "$results" | grep -c "spotify:playlist" \
                         )
 
                         if [ "$count" -gt 0 ]; then
                             random=$(( $RANDOM % $count));
 
                             SPOTIFY_PLAY_URI=$( \
-                                echo "$results" | awk -v random="$random" '/spotify:user:[a-zA-Z0-9]+:playlist:[a-zA-Z0-9]+/{i++}i==random{print; exit}' \
+                                echo "$results" | awk -v random="$random" '/spotify:playlist:[a-zA-Z0-9]+/{i++}i==random{print; exit}' \
                             )
                         fi;;
 


### PR DESCRIPTION
This removes the `:user:[a-zA-Z0-9]+` from the playlist uri and restores the ability to run `spotify play list <query>`, for example:
```bash
$ ./spotify play list czarface
Connecting to Spotify's API
Searching playlists for: czarface
Playing (czarface Search) -> Spotify URI: spotify:playlist:2Uu0L93wNGnExIlgiX6gDF
```

These functions were tested for any failures or regressions and passed:
`spotify play <query>`
`spotify play album <query>`
`spotify play artist <query>`
`spotify play track <query>`
`spotify play list <query>`

![playlist_fix](https://user-images.githubusercontent.com/5605132/56838160-0491a300-684b-11e9-9786-359f6630a2b5.png)
