### PR TITLE
Exit with 1 if Spotify isn't actually started

### DIFF
--- a/spotify
+++ b/spotify
@@ -151,8 +151,8 @@ else
 	fi
 
     if [ $(osascript -e 'application "Spotify" is running') = "false" ]; then
-        osascript -e 'tell application "Spotify" to activate' || exit 1
-        sleep 2
+        echo "The Spotify application must be started."
+        exit 1
     fi
 fi
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
Starting Spotify - if it's not actually started - is magic, and should only be done explicitly.

Thus, this PR changes starting Spotify.app via `osascript` to printing the according error and exiting with 1.

Adresses #114 