### PR TITLE
adding in volume fade to commands

### DIFF
--- a/spotify
+++ b/spotify
@@ -347,6 +347,22 @@ while [ $# -gt 0 ]; do
                     newvol=0;
                     cecho "Spotify volume level is at min.";
                 fi
+            elif [ "$2" = "fadeout" ]; then
+                if [$vol -eq 10 ]; then
+                    echo "Spotify volume already at 10%.";
+                else
+                    step=$(( vol/10 ));
+                    currVol=$((vol-10))
+                    while true do
+                        if [step -eq 1]; then
+                            break ;;
+                        fi
+                        osascript -e "tell application \"Spotify\" to set sound volume to $currVol";
+                        currVol=currVol-10
+                        step=step-1
+                        sleep 2
+                    done
+                fi
             elif [[ $2 =~ ^[0-9]+$ ]] && [[ $2 -ge 0 && $2 -le 100 ]]; then
                 newvol=$2;
                 cecho "Setting Spotify volume level to $newvol";
@@ -355,12 +371,15 @@ while [ $# -gt 0 ]; do
                 echo "The 'vol' command should be used as follows:"
                 echo "  vol up                       # Increases the volume by 10%.";
                 echo "  vol down                     # Decreases the volume by 10%.";
+                echo "  vol fadeout                  # Fades the current volume down to 10%.";
                 echo "  vol [amount]                 # Sets the volume to an amount between 0 and 100.";
                 echo "  vol                          # Shows the current Spotify volume.";
                 exit 1;
             fi
 
-            osascript -e "tell application \"Spotify\" to set sound volume to $newvol";
+            if [ "$2" -ne "fadeout" ]; then
+                osascript -e "tell application \"Spotify\" to set sound volume to $newvol";
+            fi
             break ;;
 
         "toggle"  )


### PR DESCRIPTION
@hnarayanan First, thanks for the original script included here! 

Currently we use this script to share a spotify account between users. Before meetings however, we want to be able to gracefully fade the music to a low threshhold (zero makes the room feel eerily quiet, heh). This seemed like a graceful way to approach that, but I was curious if you would be interested in including this in the original code? 
I had issues running locally, so you may want to pull and verify this works, but it seems as if it would.

Thanks again!