### PR TITLE
Update func that checks whether Spotify.app is installed

### DIFF
--- a/spotify
+++ b/spotify
@@ -145,7 +145,7 @@ showStatus () {
 if [ $# = 0 ]; then
     showHelp;
 else
-	if [ ! -d /Applications/Spotify.app ] && [ ! -d $HOME/Applications/Spotify.app ]; then
+	if [ ! $(mdfind "kMDItemKind == 'Application'" | /usr/local/bin/ggrep "Spotify.app") &>/dev/null ]; then
 		echo "The Spotify application must be installed."
 		exit 1
 	fi


### PR DESCRIPTION
Use `mdfind`/ `kMDItemKind == Application` functionality to locate Spotify.app.
Rather than hard-conding and specifying specific locations.
This helps users who may have unconventional install locations.