### PR TITLE
Play on other devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ spotify toggle shuffle             Toggles shuffle playback mode.
 spotify toggle repeat              Toggles repeat playback mode.
 
 spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
+spotify list mine <format>*        List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
+echo "                             * Please note that this requires authentication via a browser."
 ````
 
 ## Authors and contributing

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ spotify share uri                  Displays the current song's Spotify URI and c
 
 spotify toggle shuffle             Toggles shuffle playback mode.
 spotify toggle repeat              Toggles repeat playback mode.
+
+spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
 ````
 
 ## Authors and contributing

--- a/spotify
+++ b/spotify
@@ -94,8 +94,10 @@ showHelp () {
     echo;
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";
+    if [ $jq_installed = "true" ];then
     echo;
     echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
+    fi
     showAPIHelp
 }
 
@@ -184,6 +186,13 @@ getAccessToken() {
     )
 }
 
+## Check existence of jq
+if [ -x "$(command -v jq)" ]; then
+  jq_installed="true"
+else
+  jq_installed="false"
+fi
+
 if [ $# = 0 ]; then
     showHelp;
 else
@@ -197,6 +206,7 @@ else
         sleep 2
     fi
 fi
+
 while [ $# -gt 0 ]; do
     arg=$1;
 
@@ -415,24 +425,28 @@ while [ $# -gt 0 ]; do
             break ;;
 
         "list" )
-            if [ $# != 1 ]; then
-                # There are additional arguments, a status subcommand
-                case $2 in
-                    "uri" )
-                        array=( $@ );
-                        len=${#array[@]};
-                        SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
-                        SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
-                        getAccessToken;
-                        SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
-                        if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
-                          format=$3
-                        else
-                          format="csv"
-                        fi
-                        showTrackList;
-                        break ;;
-                esac
+            if [[ $jq_installed == "false" ]];then
+              echo "Unfortunately the 'list' option will not function without 'jq', a json parser. It can be installed with \"brew install jq\""
+            else
+              if [ $# != 1 ]; then
+                  # There are additional arguments, a status subcommand
+                  case $2 in
+                      "uri" )
+                          array=( $@ );
+                          len=${#array[@]};
+                          SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
+                          SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
+                          getAccessToken;
+                          SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
+                          if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
+                            format=$3
+                          else
+                            format="csv"
+                          fi
+                          showTrackList;
+                          break ;;
+                  esac
+              fi
             fi
             break ;;
 

--- a/spotify
+++ b/spotify
@@ -34,6 +34,9 @@ if ! [[ -f "${USER_CONFIG_FILE}" ]]; then
 fi
 source "${USER_CONFIG_FILE}";
 
+SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
+
+
 # Set the percent change in volume for vol up and vol down
 VOL_INCREMENT=10
 
@@ -97,6 +100,8 @@ showHelp () {
     if [ $jq_installed = "true" ];then
     echo;
     echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
+    echo "  list mine <format>*          # List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
+    echo "                               # * Please note that this requires authentication via a browser."
     fi
     showAPIHelp
 }
@@ -132,6 +137,17 @@ showTrackList() {
   cecho "$TrackList"
 }
 
+showMyPlaylists() {
+  MyPlaylists=$( \
+    curl -s -G  "https://api.spotify.com/v1/me/playlists?limit=20" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}" \
+      | jq -r --arg format "$format" '.items[] | [ .uri, .name, .public] | @'$format'' \
+  )
+  cecho "$MyPlaylists"
+}
+
 showStatus () {
     state=`osascript -e 'tell application "Spotify" to player state as string'`;
     cecho "Spotify is currently $state.";
@@ -159,6 +175,54 @@ showStatus () {
             return nowAt'`;
 
     echo -e $reset"Artist: $(showArtist)\nAlbum: $(showAlbum)\nTrack: $(showTrack) \nPosition: $position / $duration";
+}
+
+getUserAccessToken() {
+  ## Based on a gist by Hugh Rawlinson (https://gist.github.com/hughrawlinson/358afa57a04c8c0f1ce4f1fd86604a73)
+  port=8082
+  redirect_uri=http%3A%2F%2Flocalhost%3A$port%2F
+  auth_endpoint=https://accounts.spotify.com/authorize/?response_type=code\&client_id=$CLIENT_ID\&redirect_uri=$redirect_uri
+  # TODO return cached access token if scopes match and it hasn't expired
+  # TODO get scopes from args
+  scopes="playlist-read-private"
+  if [[ ! -z $scopes ]]
+  then
+    encoded_scopes=$(echo $scopes| tr ' ' '%' | sed s/%/%20/g)
+    # If scopes exists, then append them to auth_endpoint
+    auth_endpoint=$auth_endpoint\&scope=$encoded_scopes
+  fi
+
+  # If refresh_token exists and is valid for scopes, use refresh flow. No new login required
+  if [[ -r "/var/tmp/shpotify_refresh_token" ]];then
+    refresh_token=$(cat "/var/tmp/shpotify_refresh_token");
+    response=$(curl -s https://accounts.spotify.com/api/token \
+      -H "Content-Type:application/x-www-form-urlencoded" \
+      -H "Authorization: Basic $(echo -n $CLIENT_ID:$CLIENT_SECRET | base64)" \
+      -d "grant_type=refresh_token" \
+      -d "refresh_token=$refresh_token" \
+      )
+  else
+    open $auth_endpoint
+    # User is now authenticating on accounts.spotify.com...
+
+    # Now the user gets redirected to our endpoint
+    # Grab token and close browser window
+    ### DM: closinig of window/tab doesn't work that well...
+    response=$(echo "HTTP/1.1 200 OK\nAccess-Control-Allow-Origin:*\nContent-Length:65\n\n<html><script>open(location, '_self').close();</script></html>\n" | nc -l -c $port)
+    code=$(echo "$response" | grep GET | cut -d' ' -f 2 | cut -d'=' -f 2)
+
+    response=$(curl -s https://accounts.spotify.com/api/token \
+      -H "Content-Type:application/x-www-form-urlencoded" \
+      -H "Authorization: Basic ${SHPOTIFY_CREDENTIALS}" \
+      -d "grant_type=authorization_code&code=$code&redirect_uri=http%3A%2F%2Flocalhost%3A$port%2F")
+
+    ## refresh token only given during original authentication.
+    # Store the refrehs_token for later use
+    echo $response | jq -r '.refresh_token' > /var/tmp/shpotify_refresh_token
+  fi
+
+  # Output cache access token
+  SPOTIFY_USER_ACCESS_TOKEN=$(echo $response | jq -r '.access_token')
 }
 
 getAccessToken() {
@@ -430,21 +494,23 @@ while [ $# -gt 0 ]; do
             else
               if [ $# != 1 ]; then
                   # There are additional arguments, a status subcommand
+                  if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
+                    format=$3
+                  else
+                    format="csv"
+                  fi
                   case $2 in
                       "uri" )
                           array=( $@ );
                           len=${#array[@]};
                           SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
-                          SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
                           getAccessToken;
                           SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
-                          if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
-                            format=$3
-                          else
-                            format="csv"
-                          fi
                           showTrackList;
                           break ;;
+                      "mine" )
+                          getUserAccessToken;
+                          showMyPlaylists;
                   esac
               fi
             fi

--- a/spotify
+++ b/spotify
@@ -101,7 +101,7 @@ showHelp () {
     echo;
     echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
     echo "  list mine <format>*          # List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
-    echo "                               # * Please note that this requires authentication via a browser."
+    echo "                               # * Please note that this requires authentication via a browser.";
     fi
     showAPIHelp
 }
@@ -148,6 +148,28 @@ showMyPlaylists() {
   cecho "$MyPlaylists"
 }
 
+showMyDevices() {
+  MyDevices=$( \
+    curl -s -G  "https://api.spotify.com/v1/me/player/devices" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}" \
+      |  jq -r --arg format "$format" '.devices[] | [ .id, .name, .type, .is_active, .volume_percent ] | @'$format'' \
+  )
+  cecho "$MyDevices"
+}
+
+selectDevice() {
+  curl -X "PUT" "https://api.spotify.com/v1/me/player" \
+   --data "{\"device_ids\":[\"${device_id}\"]}" \
+   -H "Accept: application/json" \
+   -H "Content-Type: application/json" \
+   -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}"
+
+   sleep 2
+   osascript -e 'tell application "Spotify" to play';
+}
+
 showStatus () {
     state=`osascript -e 'tell application "Spotify" to player state as string'`;
     cecho "Spotify is currently $state.";
@@ -184,7 +206,7 @@ getUserAccessToken() {
   auth_endpoint=https://accounts.spotify.com/authorize/?response_type=code\&client_id=$CLIENT_ID\&redirect_uri=$redirect_uri
   # TODO return cached access token if scopes match and it hasn't expired
   # TODO get scopes from args
-  scopes="playlist-read-private"
+  scopes="playlist-read-private user-read-playback-state user-modify-playback-state"
   if [[ ! -z $scopes ]]
   then
     encoded_scopes=$(echo $scopes| tr ' ' '%' | sed s/%/%20/g)
@@ -511,7 +533,25 @@ while [ $# -gt 0 ]; do
                       "mine" )
                           getUserAccessToken;
                           showMyPlaylists;
+                          break ;;
+                      "devices" )
+                          getUserAccessToken;
+                          showMyDevices;
+                          break ;;
                   esac
+              fi
+            fi
+            break ;;
+
+        "connect" )
+            if [[ $jq_installed == "false" ]];then
+              echo "Unfortunately the 'connect' option will not function without 'jq', a json parser. It can be installed with \"brew install jq\""
+            else
+              if [ $# != 1 ]; then
+                  # There are additional arguments, a status subcommand
+                  device_id=$2
+                  getUserAccessToken;
+                  selectDevice;
               fi
             fi
             break ;;

--- a/spotify
+++ b/spotify
@@ -94,6 +94,8 @@ showHelp () {
     echo;
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";
+    echo;
+    echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist, format in csv|tsv|text|html";
     showAPIHelp
 }
 
@@ -114,6 +116,18 @@ showAlbum() {
 
 showTrack() {
     echo `osascript -e 'tell application "Spotify" to name of current track as string'`;
+}
+
+showTrackList() {
+  SPOTIFY_PLAYLIST_ID=`echo ${SPOTIFY_PLAYLIST_URI} | awk -F : '{print $3}'`
+  TrackList=$( \
+    curl -s -G  "https://api.spotify.com/v1/playlists/${SPOTIFY_PLAYLIST_ID}/tracks" \
+     -H "Accept: application/json" \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN} " \
+     | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[].name, .track.album.name] | @'$format'' \
+     )
+  cecho "$TrackList"
 }
 
 showStatus () {
@@ -143,6 +157,31 @@ showStatus () {
             return nowAt'`;
 
     echo -e $reset"Artist: $(showArtist)\nAlbum: $(showAlbum)\nTrack: $(showTrack) \nPosition: $position / $duration";
+}
+
+getAccessToken() {
+    cecho "Connecting to Spotify's API";
+
+    SPOTIFY_TOKEN_RESPONSE_DATA=$( \
+        curl "${SPOTIFY_TOKEN_URI}" \
+            --silent \
+            -X "POST" \
+            -H "Authorization: Basic ${SHPOTIFY_CREDENTIALS}" \
+            -d "grant_type=client_credentials" \
+    )
+    if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
+        cecho "Autorization failed, please check ${USER_CONFG_FILE}"
+        cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
+        showAPIHelp
+        exit 1
+    fi
+    SPOTIFY_ACCESS_TOKEN=$( \
+        printf "${SPOTIFY_TOKEN_RESPONSE_DATA}" \
+        | command grep -E -o '"access_token":".*",' \
+        | sed 's/"access_token"://g' \
+        | sed 's/"//g' \
+        | sed 's/,.*//g' \
+    )
 }
 
 if [ $# = 0 ]; then
@@ -181,31 +220,6 @@ while [ $# -gt 0 ]; do
                 fi
                 SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
                 SPOTIFY_PLAY_URI="";
-
-                getAccessToken() {
-                    cecho "Connecting to Spotify's API";
-
-                    SPOTIFY_TOKEN_RESPONSE_DATA=$( \
-                        curl "${SPOTIFY_TOKEN_URI}" \
-                            --silent \
-                            -X "POST" \
-                            -H "Authorization: Basic ${SHPOTIFY_CREDENTIALS}" \
-                            -d "grant_type=client_credentials" \
-                    )
-                    if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
-                        cecho "Autorization failed, please check ${USER_CONFG_FILE}"
-                        cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
-                        showAPIHelp
-                        exit 1
-                    fi
-                    SPOTIFY_ACCESS_TOKEN=$( \
-                        printf "${SPOTIFY_TOKEN_RESPONSE_DATA}" \
-                        | command grep -E -o '"access_token":".*",' \
-                        | sed 's/"access_token"://g' \
-                        | sed 's/"//g' \
-                        | sed 's/,.*//g' \
-                    )
-                }
 
                 searchAndPlay() {
                     type="$1"
@@ -397,6 +411,28 @@ while [ $# -gt 0 ]; do
             else
                 # status is the only param
                 showStatus;
+            fi
+            break ;;
+
+        "list" )
+            if [ $# != 1 ]; then
+                # There are additional arguments, a status subcommand
+                case $2 in
+                    "uri" )
+                        array=( $@ );
+                        len=${#array[@]};
+                        SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
+                        SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
+                        getAccessToken;
+                        SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
+                        if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
+                          format=$3
+                        else
+                          format="csv"
+                        fi
+                        showTrackList;
+                        break ;;
+                esac
             fi
             break ;;
 

--- a/spotify
+++ b/spotify
@@ -102,6 +102,9 @@ showHelp () {
     echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
     echo "  list mine <format>*          # List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
     echo "                               # * Please note that this requires authentication via a browser.";
+    echo "  list devices <format>        # List devices to play Spotify on. Devices must be active to be seen.";
+    echo;
+    echo "  connect <device_id>          # Connect and play music on another device. ID can be found with 'list devices'.";
     fi
     showAPIHelp
 }

--- a/spotify
+++ b/spotify
@@ -95,7 +95,7 @@ showHelp () {
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";
     echo;
-    echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist, format in csv|tsv|text|html";
+    echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
     showAPIHelp
 }
 
@@ -119,7 +119,7 @@ showTrack() {
 }
 
 showTrackList() {
-  SPOTIFY_PLAYLIST_ID=`echo ${SPOTIFY_PLAYLIST_URI} | awk -F : '{print $3}'`
+  SPOTIFY_PLAYLIST_ID=${SPOTIFY_PLAYLIST_URI##*:}
   TrackList=$( \
     curl -s -G  "https://api.spotify.com/v1/playlists/${SPOTIFY_PLAYLIST_ID}/tracks" \
      -H "Accept: application/json" \


### PR DESCRIPTION
I've made options to list and play on other devices, like phones, computers, spotify connect devices, the like. It's using the authorisation part also used for listing one's playlists. Please note that i've added a few extra 'scopes', which means a possible existing 'refresh-token' needs to be removed. 

Use `list devices` to list possible devices. Devices must be active, there's currently no history. It poops out the device id, name, type, used and volume level. 

Use `connect <device_id>` to select and play on a device. To connect by 'name' does not work (yet)

What do you think? :)
