### PR TITLE
Added 'list liked' for both albums and songs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ spotify toggle shuffle             Toggles shuffle playback mode.
 spotify toggle repeat              Toggles repeat playback mode.
 
 spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
+spotify list mine <format>*        List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
+echo "                             * Please note that this requires authentication via a browser."
 ````
 
 ## Authors and contributing

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ spotify share uri                  Displays the current song's Spotify URI and c
 
 spotify toggle shuffle             Toggles shuffle playback mode.
 spotify toggle repeat              Toggles repeat playback mode.
+
+spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
 ````
 
 ## Authors and contributing

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ following a few simple steps:
 shpotify needs to connect to Spotify’s API in order to find music by
 name. It is very likely you want this feature!
 
+Spotify API has a 'public' part, for which developer/app are sufficient,
+and it has a 'private' part, for which 'user authorization' is required.
+
 To get this to work, you first need to sign up (or into) Spotify’s
 developer site and [create an *Application*][spotify-dev]. Once you’ve
 done so, you can find its `Client ID` and `Client Secret` values and
@@ -56,6 +59,16 @@ done, it should look like the following (but with your own values):
 CLIENT_ID="abc01de2fghijk345lmnop"
 CLIENT_SECRET="qr6stu789vwxyz"
 ````
+
+If 'user authentication' is required, a spotify website will open in your
+default browser asking for permission. After granting permission, a new
+'localhost' site will be opened on port 8082 with a code in the URL. This code
+is caught by Shpotify and is used to get the user-access code and user-refresh
+token. From now it is possible to get information linked to your account, like
+your playlists, history, devices, etc.
+
+_note: thise page is supposed to automatically close, but that doesn't always
+work properly._ 
 
 ## Usage
 
@@ -95,7 +108,7 @@ spotify toggle repeat              Toggles repeat playback mode.
 
 spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
 spotify list mine <format>*        List 'my' playlists (uri, title, public), format in csv|tsv|text|html";
-spotify list history <format>*     List last played tracks (uri, title, artist, album), format in csv|tsv|text|html
+spotify list history <format>*     List 30 last played tracks (uri, title, artist, album), format in csv|tsv|text|html
                                    * Please note that this requires authentication via a browser."
 spotify -v | --version             Shows the shpotify and spotify versions.";
 ````

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ token. From now it is possible to get information linked to your account, like
 your playlists, history, devices, etc.
 
 _note: thise page is supposed to automatically close, but that doesn't always
-work properly._ 
+work properly._
 
 ## Usage
 
@@ -107,6 +107,8 @@ spotify toggle shuffle             Toggles shuffle playback mode.
 spotify toggle repeat              Toggles repeat playback mode.
 
 spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
+spotify list myalbums <format>*    List 50 of your last liked albums, format in csv|tsv|text|html";
+spotify list mytracks <format>*    List 50 of your last liked songs, format in csv|tsv|text|html";
 spotify list mine <format>*        List 'my' playlists (uri, title, public), format in csv|tsv|text|html";
 spotify list history <format>*     List 30 last played tracks (uri, title, artist, album), format in csv|tsv|text|html
                                    * Please note that this requires authentication via a browser."

--- a/spotify
+++ b/spotify
@@ -144,7 +144,7 @@ showTrackList() {
      -H "Accept: application/json" \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN} " \
-     | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[].name, .track.album.name] | @'$format'' \
+     | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[0].name, .track.album.name] | @'$format'' \
      )
   cecho "$TrackList"
 }

--- a/spotify
+++ b/spotify
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+#set -x
 # Copyright (c) 2012--2020 Harish Narayanan <mail@harishnarayanan.org>
 #
 # Contains numerous helpful contributions from Jorge Colindres, Thomas
@@ -101,10 +101,12 @@ showHelp () {
     if [ $jq_installed = "true" ];then
     echo;
     echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
+    echo "  list myalbums <format>*      # List 50 of your last liked albums, format in csv|tsv|text|html";
+    echo "  list mytracks <format>*      # List 50 of your last liked songs, format in csv|tsv|text|html";
     echo "  list mine <format>*          # List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
     echo "  list history <format>*       # List 30 last played tracks (uri, title, artist, album), format in csv|tsv|text|html";
+    echo "  list devices <format>*       # List devices to play Spotify on. Devices must be active to be seen.";
     echo "                               # * Please note that this requires authentication via a browser.";
-    echo "  list devices <format>        # List devices to play Spotify on. Devices must be active to be seen.";
     echo;
     echo "  connect <device_id>          # Connect and play music on another device. ID can be found with 'list devices'.";
     fi
@@ -182,6 +184,23 @@ showMyDevices() {
   cecho "$MyDevices"
 }
 
+showMyLiked() {
+  MyLiked=$( \
+    curl -s -G  "https://api.spotify.com/v1/me/${likefilter}?limit=50" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}" \
+  )
+
+  if [[ $likefilter == "tracks" ]];then
+    MyLiked=$(echo "$MyLiked" | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[0].name, .track.album.name] | @'$format'' )
+  else
+    MyLiked=$(echo "$MyLiked" | jq -r --arg format "$format" '.items[] | [ .album.uri, .album.artists[0].name, .album.name, .album.label, .album.release_date, .album.total_tracks, .album.popularity] | @'$format'' )
+  fi
+  cecho "$MyLiked"
+}
+
+
 selectDevice() {
   curl -X "PUT" "https://api.spotify.com/v1/me/player" \
    --data "{\"device_ids\":[\"${device_id}\"]}" \
@@ -229,7 +248,7 @@ getUserAccessToken() {
   auth_endpoint=https://accounts.spotify.com/authorize/?response_type=code\&client_id=$CLIENT_ID\&redirect_uri=$redirect_uri
   # TODO return cached access token if scopes match and it hasn't expired
   # TODO get scopes from args
-  scopes="playlist-read-private user-read-playback-state user-modify-playback-state user-read-recently-played"
+  scopes="playlist-read-private user-read-playback-state user-modify-playback-state user-read-recently-played user-library-read"
   if [[ ! -z $scopes ]]
   then
     encoded_scopes=$(echo $scopes| tr ' ' '%' | sed s/%/%20/g)
@@ -557,6 +576,18 @@ while [ $# -gt 0 ]; do
                       "history" )
                           getUserAccessToken;
                           showMyHistory;
+                          break ;;
+
+                      "mysongs" | "songs" | "tracks" )
+                          getUserAccessToken;
+                          likefilter="tracks"
+                          showMyLiked;
+                          break ;;
+
+                      "myalbums" | "albums" )
+                          getUserAccessToken;
+                          likefilter="albums"
+                          showMyLiked;
                           break ;;
 
                       "mine" )

--- a/spotify
+++ b/spotify
@@ -94,8 +94,10 @@ showHelp () {
     echo;
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";
+    if [ $jq_installed = "true" ];then
     echo;
     echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
+    fi
     showAPIHelp
 }
 
@@ -184,6 +186,13 @@ getAccessToken() {
     )
 }
 
+## Check existence of jq
+if [ -x "$(command -v jq)" ]; then
+  jq_installed="true"
+else
+  jq_installed="false"
+fi
+
 if [ $# = 0 ]; then
     showHelp;
 else
@@ -197,6 +206,7 @@ else
         sleep 2
     fi
 fi
+
 while [ $# -gt 0 ]; do
     arg=$1;
 
@@ -415,24 +425,28 @@ while [ $# -gt 0 ]; do
             break ;;
 
         "list" )
-            if [ $# != 1 ]; then
-                # There are additional arguments, a status subcommand
-                case $2 in
-                    "uri" )
-                        array=( $@ );
-                        len=${#array[@]};
-                        SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
-                        SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
-                        getAccessToken;
-                        SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
-                        if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
-                          format=$3
-                        else
-                          format="csv"
-                        fi
-                        showTrackList;
-                        break ;;
-                esac
+            if [[ $jq_installed == "false" ]];then
+              echo "Unfortunately the 'list' option will not function without 'jq', a json parser. It can be installed with \"brew install jq\""
+            else
+              if [ $# != 1 ]; then
+                  # There are additional arguments, a status subcommand
+                  case $2 in
+                      "uri" )
+                          array=( $@ );
+                          len=${#array[@]};
+                          SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
+                          SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
+                          getAccessToken;
+                          SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
+                          if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
+                            format=$3
+                          else
+                            format="csv"
+                          fi
+                          showTrackList;
+                          break ;;
+                  esac
+              fi
             fi
             break ;;
 

--- a/spotify
+++ b/spotify
@@ -34,6 +34,9 @@ if ! [[ -f "${USER_CONFIG_FILE}" ]]; then
 fi
 source "${USER_CONFIG_FILE}";
 
+SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
+
+
 # Set the percent change in volume for vol up and vol down
 VOL_INCREMENT=10
 
@@ -97,6 +100,8 @@ showHelp () {
     if [ $jq_installed = "true" ];then
     echo;
     echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
+    echo "  list mine <format>*          # List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
+    echo "                               # * Please note that this requires authentication via a browser."
     fi
     showAPIHelp
 }
@@ -132,6 +137,17 @@ showTrackList() {
   cecho "$TrackList"
 }
 
+showMyPlaylists() {
+  MyPlaylists=$( \
+    curl -s -G  "https://api.spotify.com/v1/me/playlists?limit=20" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}" \
+      | jq -r --arg format "$format" '.items[] | [ .uri, .name, .public] | @'$format'' \
+  )
+  cecho "$MyPlaylists"
+}
+
 showStatus () {
     state=`osascript -e 'tell application "Spotify" to player state as string'`;
     cecho "Spotify is currently $state.";
@@ -159,6 +175,54 @@ showStatus () {
             return nowAt'`;
 
     echo -e $reset"Artist: $(showArtist)\nAlbum: $(showAlbum)\nTrack: $(showTrack) \nPosition: $position / $duration";
+}
+
+getUserAccessToken() {
+  ## Based on a gist by Hugh Rawlinson (https://gist.github.com/hughrawlinson/358afa57a04c8c0f1ce4f1fd86604a73)
+  port=8082
+  redirect_uri=http%3A%2F%2Flocalhost%3A$port%2F
+  auth_endpoint=https://accounts.spotify.com/authorize/?response_type=code\&client_id=$CLIENT_ID\&redirect_uri=$redirect_uri
+  # TODO return cached access token if scopes match and it hasn't expired
+  # TODO get scopes from args
+  scopes="playlist-read-private"
+  if [[ ! -z $scopes ]]
+  then
+    encoded_scopes=$(echo $scopes| tr ' ' '%' | sed s/%/%20/g)
+    # If scopes exists, then append them to auth_endpoint
+    auth_endpoint=$auth_endpoint\&scope=$encoded_scopes
+  fi
+
+  # If refresh_token exists and is valid for scopes, use refresh flow. No new login required
+  if [[ -r "/var/tmp/shpotify_refresh_token" ]];then
+    refresh_token=$(cat "/var/tmp/shpotify_refresh_token");
+    response=$(curl -s https://accounts.spotify.com/api/token \
+      -H "Content-Type:application/x-www-form-urlencoded" \
+      -H "Authorization: Basic $(echo -n $CLIENT_ID:$CLIENT_SECRET | base64)" \
+      -d "grant_type=refresh_token" \
+      -d "refresh_token=$refresh_token" \
+      )
+  else
+    open $auth_endpoint
+    # User is now authenticating on accounts.spotify.com...
+
+    # Now the user gets redirected to our endpoint
+    # Grab token and close browser window
+    ### DM: closinig of window/tab doesn't work that well...
+    response=$(echo "HTTP/1.1 200 OK\nAccess-Control-Allow-Origin:*\nContent-Length:65\n\n<html><script>open(location, '_self').close();</script></html>\n" | nc -l -c $port)
+    code=$(echo "$response" | grep GET | cut -d' ' -f 2 | cut -d'=' -f 2)
+
+    response=$(curl -s https://accounts.spotify.com/api/token \
+      -H "Content-Type:application/x-www-form-urlencoded" \
+      -H "Authorization: Basic ${SHPOTIFY_CREDENTIALS}" \
+      -d "grant_type=authorization_code&code=$code&redirect_uri=http%3A%2F%2Flocalhost%3A$port%2F")
+
+    ## refresh token only given during original authentication.
+    # Store the refrehs_token for later use
+    echo $response | jq -r '.refresh_token' > /var/tmp/shpotify_refresh_token
+  fi
+
+  # Output cache access token
+  SPOTIFY_USER_ACCESS_TOKEN=$(echo $response | jq -r '.access_token')
 }
 
 getAccessToken() {
@@ -430,21 +494,23 @@ while [ $# -gt 0 ]; do
             else
               if [ $# != 1 ]; then
                   # There are additional arguments, a status subcommand
+                  if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
+                    format=$3
+                  else
+                    format="csv"
+                  fi
                   case $2 in
                       "uri" )
                           array=( $@ );
                           len=${#array[@]};
                           SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
-                          SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
                           getAccessToken;
                           SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
-                          if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
-                            format=$3
-                          else
-                            format="csv"
-                          fi
                           showTrackList;
                           break ;;
+                      "mine" )
+                          getUserAccessToken;
+                          showMyPlaylists;
                   esac
               fi
             fi

--- a/spotify
+++ b/spotify
@@ -94,6 +94,8 @@ showHelp () {
     echo;
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";
+    echo;
+    echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist, format in csv|tsv|text|html";
     showAPIHelp
 }
 
@@ -114,6 +116,18 @@ showAlbum() {
 
 showTrack() {
     echo `osascript -e 'tell application "Spotify" to name of current track as string'`;
+}
+
+showTrackList() {
+  SPOTIFY_PLAYLIST_ID=`echo ${SPOTIFY_PLAYLIST_URI} | awk -F : '{print $3}'`
+  TrackList=$( \
+    curl -s -G  "https://api.spotify.com/v1/playlists/${SPOTIFY_PLAYLIST_ID}/tracks" \
+     -H "Accept: application/json" \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN} " \
+     | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[].name, .track.album.name] | @'$format'' \
+     )
+  cecho "$TrackList"
 }
 
 showStatus () {
@@ -143,6 +157,31 @@ showStatus () {
             return nowAt'`;
 
     echo -e $reset"Artist: $(showArtist)\nAlbum: $(showAlbum)\nTrack: $(showTrack) \nPosition: $position / $duration";
+}
+
+getAccessToken() {
+    cecho "Connecting to Spotify's API";
+
+    SPOTIFY_TOKEN_RESPONSE_DATA=$( \
+        curl "${SPOTIFY_TOKEN_URI}" \
+            --silent \
+            -X "POST" \
+            -H "Authorization: Basic ${SHPOTIFY_CREDENTIALS}" \
+            -d "grant_type=client_credentials" \
+    )
+    if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
+        cecho "Autorization failed, please check ${USER_CONFG_FILE}"
+        cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
+        showAPIHelp
+        exit 1
+    fi
+    SPOTIFY_ACCESS_TOKEN=$( \
+        printf "${SPOTIFY_TOKEN_RESPONSE_DATA}" \
+        | command grep -E -o '"access_token":".*",' \
+        | sed 's/"access_token"://g' \
+        | sed 's/"//g' \
+        | sed 's/,.*//g' \
+    )
 }
 
 if [ $# = 0 ]; then
@@ -181,31 +220,6 @@ while [ $# -gt 0 ]; do
                 fi
                 SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
                 SPOTIFY_PLAY_URI="";
-
-                getAccessToken() {
-                    cecho "Connecting to Spotify's API";
-
-                    SPOTIFY_TOKEN_RESPONSE_DATA=$( \
-                        curl "${SPOTIFY_TOKEN_URI}" \
-                            --silent \
-                            -X "POST" \
-                            -H "Authorization: Basic ${SHPOTIFY_CREDENTIALS}" \
-                            -d "grant_type=client_credentials" \
-                    )
-                    if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
-                        cecho "Autorization failed, please check ${USER_CONFG_FILE}"
-                        cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
-                        showAPIHelp
-                        exit 1
-                    fi
-                    SPOTIFY_ACCESS_TOKEN=$( \
-                        printf "${SPOTIFY_TOKEN_RESPONSE_DATA}" \
-                        | command grep -E -o '"access_token":".*",' \
-                        | sed 's/"access_token"://g' \
-                        | sed 's/"//g' \
-                        | sed 's/,.*//g' \
-                    )
-                }
 
                 searchAndPlay() {
                     type="$1"
@@ -397,6 +411,28 @@ while [ $# -gt 0 ]; do
             else
                 # status is the only param
                 showStatus;
+            fi
+            break ;;
+
+        "list" )
+            if [ $# != 1 ]; then
+                # There are additional arguments, a status subcommand
+                case $2 in
+                    "uri" )
+                        array=( $@ );
+                        len=${#array[@]};
+                        SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
+                        SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
+                        getAccessToken;
+                        SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
+                        if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
+                          format=$3
+                        else
+                          format="csv"
+                        fi
+                        showTrackList;
+                        break ;;
+                esac
             fi
             break ;;
 

--- a/spotify
+++ b/spotify
@@ -95,7 +95,7 @@ showHelp () {
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";
     echo;
-    echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist, format in csv|tsv|text|html";
+    echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
     showAPIHelp
 }
 
@@ -119,7 +119,7 @@ showTrack() {
 }
 
 showTrackList() {
-  SPOTIFY_PLAYLIST_ID=`echo ${SPOTIFY_PLAYLIST_URI} | awk -F : '{print $3}'`
+  SPOTIFY_PLAYLIST_ID=${SPOTIFY_PLAYLIST_URI##*:}
   TrackList=$( \
     curl -s -G  "https://api.spotify.com/v1/playlists/${SPOTIFY_PLAYLIST_ID}/tracks" \
      -H "Accept: application/json" \


### PR DESCRIPTION
I've added a 'list liked' option for both albums and song: list myalbums <format>*,  list mytracks <format>*. Format in csv/tsv/test/html.

It poops out the last 50 liked songs or albums. 50 is the he spotify API limit. A possible future workaround could be looping the command with an offset to get all songs/albums, but that hasn't been implemented yet. 

Another thingy: I couldn't decide about the syntax. Songs/tracks/mytracks or myalbums/albums. They all work for the moment, but only 'myalbums and mytracks are put in the 'help' output for now. 

This is a prelude to 'issue' #69. 
