### PR TITLE
Like uri 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ spotify status                     Shows the play status, including the current 
 spotify status artist              Shows the currently playing artist.
 spotify status album               Shows the currently playing album.
 spotify status track               Shows the currently playing track.
+spotify status liked <uri>*        Shows if a track or album is liked or not.
 
 spotify share                      Displays the current song's Spotify URL and URI.
 spotify share url                  Displays the current song's Spotify URL and copies it to the clipboard.
@@ -106,13 +107,17 @@ spotify share uri                  Displays the current song's Spotify URI and c
 spotify toggle shuffle             Toggles shuffle playback mode.
 spotify toggle repeat              Toggles repeat playback mode.
 
-spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
+spotify list uri <format> <uri>    List information about track, album or playlist by uri. Format in csv|tsv|text|html"
 spotify list myalbums <format>*    List 50 of your last liked albums, format in csv|tsv|text|html";
 spotify list mytracks <format>*    List 50 of your last liked songs, format in csv|tsv|text|html";
 spotify list mine <format>*        List 'my' playlists (uri, title, public), format in csv|tsv|text|html";
 spotify list history <format>*     List 30 last played tracks (uri, title, artist, album), format in csv|tsv|text|html
-                                   * Please note that this requires authentication via a browser."
+
+spotify like <uri>*                Like a song or album and add it to your library.";
+
 spotify -v | --version             Shows the shpotify and spotify versions.";
+
+* Please note that this requires authentication via a browser."
 ````
 
 ## Authors and contributing

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ spotify toggle shuffle             Toggles shuffle playback mode.
 spotify toggle repeat              Toggles repeat playback mode.
 
 spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
+spotify list mine <format>*        List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
+echo "                             * Please note that this requires authentication via a browser."
 ````
 
 ## Authors and contributing

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ spotify share uri                  Displays the current song's Spotify URI and c
 
 spotify toggle shuffle             Toggles shuffle playback mode.
 spotify toggle repeat              Toggles repeat playback mode.
+
+spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
 ````
 
 ## Authors and contributing

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ following a few simple steps:
 shpotify needs to connect to Spotify’s API in order to find music by
 name. It is very likely you want this feature!
 
+Spotify API has a 'public' part, for which developer/app are sufficient,
+and it has a 'private' part, for which 'user authorization' is required.
+
 To get this to work, you first need to sign up (or into) Spotify’s
 developer site and [create an *Application*][spotify-dev]. Once you’ve
 done so, you can find its `Client ID` and `Client Secret` values and
@@ -56,6 +59,16 @@ done, it should look like the following (but with your own values):
 CLIENT_ID="abc01de2fghijk345lmnop"
 CLIENT_SECRET="qr6stu789vwxyz"
 ````
+
+If 'user authentication' is required, a spotify website will open in your
+default browser asking for permission. After granting permission, a new
+'localhost' site will be opened on port 8082 with a code in the URL. This code
+is caught by Shpotify and is used to get the user-access code and user-refresh
+token. From now it is possible to get information linked to your account, like
+your playlists, history, devices, etc.
+
+_note: thise page is supposed to automatically close, but that doesn't always
+work properly._ 
 
 ## Usage
 
@@ -95,7 +108,7 @@ spotify toggle repeat              Toggles repeat playback mode.
 
 spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
 spotify list mine <format>*        List 'my' playlists (uri, title, public), format in csv|tsv|text|html";
-spotify list history <format>*     List last played tracks (uri, title, artist, album), format in csv|tsv|text|html
+spotify list history <format>*     List 30 last played tracks (uri, title, artist, album), format in csv|tsv|text|html
                                    * Please note that this requires authentication via a browser."
 spotify -v | --version             Shows the shpotify and spotify versions.";
 ````

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ token. From now it is possible to get information linked to your account, like
 your playlists, history, devices, etc.
 
 _note: thise page is supposed to automatically close, but that doesn't always
-work properly._ 
+work properly._
 
 ## Usage
 
@@ -107,6 +107,8 @@ spotify toggle shuffle             Toggles shuffle playback mode.
 spotify toggle repeat              Toggles repeat playback mode.
 
 spotify list uri <format> <uri>    List uri,title,artist and album of specific playlist, format in csv|tsv|text|html"
+spotify list myalbums <format>*    List 50 of your last liked albums, format in csv|tsv|text|html";
+spotify list mytracks <format>*    List 50 of your last liked songs, format in csv|tsv|text|html";
 spotify list mine <format>*        List 'my' playlists (uri, title, public), format in csv|tsv|text|html";
 spotify list history <format>*     List 30 last played tracks (uri, title, artist, album), format in csv|tsv|text|html
                                    * Please note that this requires authentication via a browser."

--- a/spotify
+++ b/spotify
@@ -200,6 +200,40 @@ showMyLiked() {
   cecho "$MyLiked"
 }
 
+showURIinfo() {
+  read URI_TYPE URI_ID <<<$(echo "$1" | awk -F ":" '{print $2,$3}')
+  URI_INFO=$( \
+    curl -s -G  "https://api.spotify.com/v1/${URI_TYPE}s/${URI_ID}" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}" \
+  )
+
+  format=csv
+  if [[ $URI_TYPE == "track" ]];then
+    URI_INFO=$(echo "$URI_INFO" | jq -r --arg format "$format" '[.name, .artists[0].name, .album.name] | @csv' )
+  else
+    URI_INFO=$(echo "$URI_INFO" | jq -r --arg format "$format" '.items[] | [ .album.uri, .album.artists[0].name, .album.name, .album.label, .album.release_date, .album.total_tracks, .album.popularity] | @'$format'' )
+  fi
+
+  cecho "${URI_INFO}"
+}
+
+likeURI() {
+
+  read URI_TYPE URI_ID <<<$(echo "$1" | awk -F ":" '{print $2,$3}')
+  # TODO: check if already liked
+  # TODO: test with albums
+  curl -X "PUT" "https://api.spotify.com/v1/me/${URI_TYPE}s?ids=${URI_ID}" \
+   -H "Accept: application/json" \
+   -H "Content-Type: application/json" \
+   -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}"
+
+   sleep 1
+   cecho " The following ${URI_TYPE} has been liked: "
+   showURIinfo ${1}
+}
+
 
 selectDevice() {
   curl -X "PUT" "https://api.spotify.com/v1/me/player" \
@@ -248,7 +282,7 @@ getUserAccessToken() {
   auth_endpoint=https://accounts.spotify.com/authorize/?response_type=code\&client_id=$CLIENT_ID\&redirect_uri=$redirect_uri
   # TODO return cached access token if scopes match and it hasn't expired
   # TODO get scopes from args
-  scopes="playlist-read-private user-read-playback-state user-modify-playback-state user-read-recently-played user-library-read"
+  scopes="playlist-read-private user-read-playback-state user-modify-playback-state user-read-recently-played user-library-read user-library-modify"
   if [[ ! -z $scopes ]]
   then
     encoded_scopes=$(echo $scopes| tr ' ' '%' | sed s/%/%20/g)
@@ -602,6 +636,20 @@ while [ $# -gt 0 ]; do
                   esac
               fi
             fi
+            break ;;
+
+        "like" )
+            array=( $@ );
+            len=${#array[@]};
+            URIs=${array[@]:1:$len};
+            getUserAccessToken;
+            # echo "$URIs"
+            for i in $URIs
+            do
+              likeURI ${i};
+            done
+            #SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
+            #likeURI
             break ;;
 
         "connect" )

--- a/spotify
+++ b/spotify
@@ -144,7 +144,7 @@ showTrackList() {
      -H "Accept: application/json" \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN} " \
-     | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[].name, .track.album.name] | @'$format'' \
+     | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[0].name, .track.album.name] | @'$format'' \
      )
   cecho "$TrackList"
 }

--- a/spotify
+++ b/spotify
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+#set -x
 # Copyright (c) 2012--2020 Harish Narayanan <mail@harishnarayanan.org>
 #
 # Contains numerous helpful contributions from Jorge Colindres, Thomas
@@ -101,10 +101,12 @@ showHelp () {
     if [ $jq_installed = "true" ];then
     echo;
     echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
+    echo "  list myalbums <format>*      # List 50 of your last liked albums, format in csv|tsv|text|html";
+    echo "  list mytracks <format>*      # List 50 of your last liked songs, format in csv|tsv|text|html";
     echo "  list mine <format>*          # List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
     echo "  list history <format>*       # List 30 last played tracks (uri, title, artist, album), format in csv|tsv|text|html";
+    echo "  list devices <format>*       # List devices to play Spotify on. Devices must be active to be seen.";
     echo "                               # * Please note that this requires authentication via a browser.";
-    echo "  list devices <format>        # List devices to play Spotify on. Devices must be active to be seen.";
     echo;
     echo "  connect <device_id>          # Connect and play music on another device. ID can be found with 'list devices'.";
     fi
@@ -182,6 +184,23 @@ showMyDevices() {
   cecho "$MyDevices"
 }
 
+showMyLiked() {
+  MyLiked=$( \
+    curl -s -G  "https://api.spotify.com/v1/me/${likefilter}?limit=50" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}" \
+  )
+
+  if [[ $likefilter == "tracks" ]];then
+    MyLiked=$(echo "$MyLiked" | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[0].name, .track.album.name] | @'$format'' )
+  else
+    MyLiked=$(echo "$MyLiked" | jq -r --arg format "$format" '.items[] | [ .album.uri, .album.artists[0].name, .album.name, .album.label, .album.release_date, .album.total_tracks, .album.popularity] | @'$format'' )
+  fi
+  cecho "$MyLiked"
+}
+
+
 selectDevice() {
   curl -X "PUT" "https://api.spotify.com/v1/me/player" \
    --data "{\"device_ids\":[\"${device_id}\"]}" \
@@ -229,7 +248,7 @@ getUserAccessToken() {
   auth_endpoint=https://accounts.spotify.com/authorize/?response_type=code\&client_id=$CLIENT_ID\&redirect_uri=$redirect_uri
   # TODO return cached access token if scopes match and it hasn't expired
   # TODO get scopes from args
-  scopes="playlist-read-private user-read-playback-state user-modify-playback-state user-read-recently-played"
+  scopes="playlist-read-private user-read-playback-state user-modify-playback-state user-read-recently-played user-library-read"
   if [[ ! -z $scopes ]]
   then
     encoded_scopes=$(echo $scopes| tr ' ' '%' | sed s/%/%20/g)
@@ -557,6 +576,18 @@ while [ $# -gt 0 ]; do
                       "history" )
                           getUserAccessToken;
                           showMyHistory;
+                          break ;;
+
+                      "mysongs" | "songs" | "tracks" )
+                          getUserAccessToken;
+                          likefilter="tracks"
+                          showMyLiked;
+                          break ;;
+
+                      "myalbums" | "albums" )
+                          getUserAccessToken;
+                          likefilter="albums"
+                          showMyLiked;
                           break ;;
 
                       "mine" )

--- a/spotify
+++ b/spotify
@@ -94,8 +94,10 @@ showHelp () {
     echo;
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";
+    if [ $jq_installed = "true" ];then
     echo;
     echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
+    fi
     showAPIHelp
 }
 
@@ -184,6 +186,13 @@ getAccessToken() {
     )
 }
 
+## Check existence of jq
+if [ -x "$(command -v jq)" ]; then
+  jq_installed="true"
+else
+  jq_installed="false"
+fi
+
 if [ $# = 0 ]; then
     showHelp;
 else
@@ -197,6 +206,7 @@ else
         sleep 2
     fi
 fi
+
 while [ $# -gt 0 ]; do
     arg=$1;
 
@@ -415,24 +425,28 @@ while [ $# -gt 0 ]; do
             break ;;
 
         "list" )
-            if [ $# != 1 ]; then
-                # There are additional arguments, a status subcommand
-                case $2 in
-                    "uri" )
-                        array=( $@ );
-                        len=${#array[@]};
-                        SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
-                        SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
-                        getAccessToken;
-                        SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
-                        if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
-                          format=$3
-                        else
-                          format="csv"
-                        fi
-                        showTrackList;
-                        break ;;
-                esac
+            if [[ $jq_installed == "false" ]];then
+              echo "Unfortunately the 'list' option will not function without 'jq', a json parser. It can be installed with \"brew install jq\""
+            else
+              if [ $# != 1 ]; then
+                  # There are additional arguments, a status subcommand
+                  case $2 in
+                      "uri" )
+                          array=( $@ );
+                          len=${#array[@]};
+                          SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
+                          SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
+                          getAccessToken;
+                          SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
+                          if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
+                            format=$3
+                          else
+                            format="csv"
+                          fi
+                          showTrackList;
+                          break ;;
+                  esac
+              fi
             fi
             break ;;
 

--- a/spotify
+++ b/spotify
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#set -x
+
 # Copyright (c) 2012--2020 Harish Narayanan <mail@harishnarayanan.org>
 #
 # Contains numerous helpful contributions from Jorge Colindres, Thomas
@@ -91,6 +91,7 @@ showHelp () {
     echo "  status artist                # Shows the currently playing artist.";
     echo "  status album                 # Shows the currently playing album.";
     echo "  status track                 # Shows the currently playing track.";
+    echo "  status liked <uri>*          # Shows of a track or album is liked.";
     echo;
     echo "  share                        # Displays the current song's Spotify URL and URI."
     echo "  share url                    # Displays the current song's Spotify URL and copies it to the clipboard."
@@ -100,18 +101,20 @@ showHelp () {
     echo "  toggle repeat                # Toggles repeat playback mode.";
     if [ $jq_installed = "true" ];then
     echo;
-    echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
+    echo "  list uri <format> <uri>      # List information about track, album or playlist uri. Format in csv|tsv|text|html";
     echo "  list myalbums <format>*      # List 50 of your last liked albums, format in csv|tsv|text|html";
     echo "  list mytracks <format>*      # List 50 of your last liked songs, format in csv|tsv|text|html";
     echo "  list mine <format>*          # List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
     echo "  list history <format>*       # List 30 last played tracks (uri, title, artist, album), format in csv|tsv|text|html";
     echo "  list devices <format>*       # List devices to play Spotify on. Devices must be active to be seen.";
-    echo "                               # * Please note that this requires authentication via a browser.";
+    echo;
+    echo "  like <uri>*                  # Like a song or album and add it to your library.";
     echo;
     echo "  connect <device_id>          # Connect and play music on another device. ID can be found with 'list devices'.";
     fi
     echo;
     echo "  -v | --version               # Shows the shpotify and spotify versions.";
+    echo "* Please note that this requires authentication via a browser.";
     showAPIHelp
 }
 
@@ -137,18 +140,6 @@ showAlbum() {
 
 showTrack() {
     echo `osascript -e 'tell application "Spotify" to name of current track as string'`;
-}
-
-showTrackList() {
-  SPOTIFY_PLAYLIST_ID=${SPOTIFY_PLAYLIST_URI##*:}
-  TrackList=$( \
-    curl -s -G  "https://api.spotify.com/v1/playlists/${SPOTIFY_PLAYLIST_ID}/tracks" \
-     -H "Accept: application/json" \
-     -H "Content-Type: application/json" \
-     -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN} " \
-     | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[0].name, .track.album.name] | @'$format'' \
-     )
-  cecho "$TrackList"
 }
 
 showMyPlaylists() {
@@ -200,20 +191,44 @@ showMyLiked() {
   cecho "$MyLiked"
 }
 
-showURIinfo() {
-  read URI_TYPE URI_ID <<<$(echo "$1" | awk -F ":" '{print $2,$3}')
-  URI_INFO=$( \
-    curl -s -G  "https://api.spotify.com/v1/${URI_TYPE}s/${URI_ID}" \
+checkLiked() {
+  read URI_TYPE URI_ID <<<$(echo "$URI" | awk -F ":" '{print $2,$3}')
+  ItIsLiked=$(
+    curl -s -G  "https://api.spotify.com/v1/me/${URI_TYPE}s/contains?ids=${URI_ID}" \
       -H "Accept: application/json" \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}" \
-  )
+      )
+}
 
-  format=csv
-  if [[ $URI_TYPE == "track" ]];then
-    URI_INFO=$(echo "$URI_INFO" | jq -r --arg format "$format" '[.name, .artists[0].name, .album.name] | @csv' )
+showURIinfo() {
+  read URI_TYPE URI_ID <<<$(echo "$URI" | awk -F ":" '{print $2,$3}')
+  if [[ $URI_TYPE == "playlist" ]];then
+    SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
+    getAccessToken
+    URI_INFO=$( \
+      curl -s -G  "https://api.spotify.com/v1/${URI_TYPE}s/${URI_ID}/tracks" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN} "
+      )
   else
-    URI_INFO=$(echo "$URI_INFO" | jq -r --arg format "$format" '.items[] | [ .album.uri, .album.artists[0].name, .album.name, .album.label, .album.release_date, .album.total_tracks, .album.popularity] | @'$format'' )
+    getUserAccessToken
+    URI_INFO=$( \
+      curl -s -G  "https://api.spotify.com/v1/${URI_TYPE}s/${URI_ID}" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}" \
+      )
+  fi
+
+#  format=csv
+  if [[ $URI_TYPE == "playlist" ]];then
+    URI_INFO=$(echo "$URI_INFO" | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[0].name, .track.album.name] | @'$format'' )
+  elif [[ $URI_TYPE == "track" ]];then
+    URI_INFO=$(echo "$URI_INFO" | jq -r --arg format "$format" '[.uri, .name, .artists[0].name, .album.name] | @'$format'' )
+  else
+    URI_INFO=$(echo "$URI_INFO" | jq -r --arg format "$format" '[.uri, .name, .artists[0].name, .release_date] | @'$format'' )
   fi
 
   cecho "${URI_INFO}"
@@ -221,17 +236,21 @@ showURIinfo() {
 
 likeURI() {
 
-  read URI_TYPE URI_ID <<<$(echo "$1" | awk -F ":" '{print $2,$3}')
-  # TODO: check if already liked
-  # TODO: test with albums
-  curl -X "PUT" "https://api.spotify.com/v1/me/${URI_TYPE}s?ids=${URI_ID}" \
-   -H "Accept: application/json" \
-   -H "Content-Type: application/json" \
-   -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}"
-
-   sleep 1
-   cecho " The following ${URI_TYPE} has been liked: "
-   showURIinfo ${1}
+  read URI_TYPE URI_ID <<<$(echo "$URI" | awk -F ":" '{print $2,$3}')
+  if [[ $URI_TYPE ==  "track" || $URI_TYPE == "album" ]];then
+    checkLiked
+    if [[ $ItIsLiked == "[ true ]" ]];then
+      cecho "oops, you already like `showURIinfo`"
+    else
+      curl -X "PUT" "https://api.spotify.com/v1/me/${URI_TYPE}s?ids=${URI_ID}" \
+       -H "Accept: application/json" \
+       -H "Content-Type: application/json" \
+       -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}"
+      showURIinfo
+    fi
+  else
+   cecho "oops, you try to like a ${URI_TYPE}, but that's not possible for now."
+  fi
 }
 
 
@@ -579,6 +598,24 @@ while [ $# -gt 0 ]; do
                     "track" )
                         showTrack;
                         break ;;
+
+                    "liked" )
+                        array=( $@ );
+                        len=${#array[@]};
+                        URIs=${array[@]:2:$len};
+                        format="tsv";
+                        getUserAccessToken;
+                        for URI in $URIs;
+                        do
+                          checkLiked;
+                          if [[ $ItIsLiked == "[ true ]" ]];then
+                            cecho "You like: `showURIinfo`"
+                          else
+                            cecho "You don't like (yet): `showURIinfo`"
+                          fi
+                        done
+                        break ;;
+
                 esac
             else
                 # status is the only param
@@ -595,16 +632,14 @@ while [ $# -gt 0 ]; do
                   if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
                     format=$3
                   else
-                    format="csv"
+                    format="tsv"
                   fi
                   case $2 in
                       "uri" )
                           array=( $@ );
                           len=${#array[@]};
-                          SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
-                          getAccessToken;
-                          SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
-                          showTrackList;
+                          URI=${array[@]:2:$len};
+                          showURIinfo;
                           break ;;
 
                       "history" )
@@ -642,14 +677,14 @@ while [ $# -gt 0 ]; do
             array=( $@ );
             len=${#array[@]};
             URIs=${array[@]:1:$len};
+            format="tsv"
             getUserAccessToken;
-            # echo "$URIs"
-            for i in $URIs
+            cecho "You like: "
+            for URI in $URIs
             do
-              likeURI ${i};
+              likeURI;
+              sleep 1
             done
-            #SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
-            #likeURI
             break ;;
 
         "connect" )

--- a/spotify
+++ b/spotify
@@ -34,6 +34,9 @@ if ! [[ -f "${USER_CONFIG_FILE}" ]]; then
 fi
 source "${USER_CONFIG_FILE}";
 
+SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
+
+
 # Set the percent change in volume for vol up and vol down
 VOL_INCREMENT=10
 
@@ -97,6 +100,8 @@ showHelp () {
     if [ $jq_installed = "true" ];then
     echo;
     echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
+    echo "  list mine <format>*          # List 'my' playlists (uri, title, public), format in csv|tsv|texst|html";
+    echo "                               # * Please note that this requires authentication via a browser."
     fi
     showAPIHelp
 }
@@ -132,6 +137,17 @@ showTrackList() {
   cecho "$TrackList"
 }
 
+showMyPlaylists() {
+  MyPlaylists=$( \
+    curl -s -G  "https://api.spotify.com/v1/me/playlists?limit=20" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${SPOTIFY_USER_ACCESS_TOKEN}" \
+      | jq -r --arg format "$format" '.items[] | [ .uri, .name, .public] | @'$format'' \
+  )
+  cecho "$MyPlaylists"
+}
+
 showStatus () {
     state=`osascript -e 'tell application "Spotify" to player state as string'`;
     cecho "Spotify is currently $state.";
@@ -159,6 +175,54 @@ showStatus () {
             return nowAt'`;
 
     echo -e $reset"Artist: $(showArtist)\nAlbum: $(showAlbum)\nTrack: $(showTrack) \nPosition: $position / $duration";
+}
+
+getUserAccessToken() {
+  ## Based on a gist by Hugh Rawlinson (https://gist.github.com/hughrawlinson/358afa57a04c8c0f1ce4f1fd86604a73)
+  port=8082
+  redirect_uri=http%3A%2F%2Flocalhost%3A$port%2F
+  auth_endpoint=https://accounts.spotify.com/authorize/?response_type=code\&client_id=$CLIENT_ID\&redirect_uri=$redirect_uri
+  # TODO return cached access token if scopes match and it hasn't expired
+  # TODO get scopes from args
+  scopes="playlist-read-private"
+  if [[ ! -z $scopes ]]
+  then
+    encoded_scopes=$(echo $scopes| tr ' ' '%' | sed s/%/%20/g)
+    # If scopes exists, then append them to auth_endpoint
+    auth_endpoint=$auth_endpoint\&scope=$encoded_scopes
+  fi
+
+  # If refresh_token exists and is valid for scopes, use refresh flow. No new login required
+  if [[ -r "/var/tmp/shpotify_refresh_token" ]];then
+    refresh_token=$(cat "/var/tmp/shpotify_refresh_token");
+    response=$(curl -s https://accounts.spotify.com/api/token \
+      -H "Content-Type:application/x-www-form-urlencoded" \
+      -H "Authorization: Basic $(echo -n $CLIENT_ID:$CLIENT_SECRET | base64)" \
+      -d "grant_type=refresh_token" \
+      -d "refresh_token=$refresh_token" \
+      )
+  else
+    open $auth_endpoint
+    # User is now authenticating on accounts.spotify.com...
+
+    # Now the user gets redirected to our endpoint
+    # Grab token and close browser window
+    ### DM: closinig of window/tab doesn't work that well...
+    response=$(echo "HTTP/1.1 200 OK\nAccess-Control-Allow-Origin:*\nContent-Length:65\n\n<html><script>open(location, '_self').close();</script></html>\n" | nc -l -c $port)
+    code=$(echo "$response" | grep GET | cut -d' ' -f 2 | cut -d'=' -f 2)
+
+    response=$(curl -s https://accounts.spotify.com/api/token \
+      -H "Content-Type:application/x-www-form-urlencoded" \
+      -H "Authorization: Basic ${SHPOTIFY_CREDENTIALS}" \
+      -d "grant_type=authorization_code&code=$code&redirect_uri=http%3A%2F%2Flocalhost%3A$port%2F")
+
+    ## refresh token only given during original authentication.
+    # Store the refrehs_token for later use
+    echo $response | jq -r '.refresh_token' > /var/tmp/shpotify_refresh_token
+  fi
+
+  # Output cache access token
+  SPOTIFY_USER_ACCESS_TOKEN=$(echo $response | jq -r '.access_token')
 }
 
 getAccessToken() {
@@ -430,21 +494,23 @@ while [ $# -gt 0 ]; do
             else
               if [ $# != 1 ]; then
                   # There are additional arguments, a status subcommand
+                  if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
+                    format=$3
+                  else
+                    format="csv"
+                  fi
                   case $2 in
                       "uri" )
                           array=( $@ );
                           len=${#array[@]};
                           SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
-                          SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
                           getAccessToken;
                           SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
-                          if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
-                            format=$3
-                          else
-                            format="csv"
-                          fi
                           showTrackList;
                           break ;;
+                      "mine" )
+                          getUserAccessToken;
+                          showMyPlaylists;
                   esac
               fi
             fi

--- a/spotify
+++ b/spotify
@@ -94,6 +94,8 @@ showHelp () {
     echo;
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";
+    echo;
+    echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist, format in csv|tsv|text|html";
     showAPIHelp
 }
 
@@ -114,6 +116,18 @@ showAlbum() {
 
 showTrack() {
     echo `osascript -e 'tell application "Spotify" to name of current track as string'`;
+}
+
+showTrackList() {
+  SPOTIFY_PLAYLIST_ID=`echo ${SPOTIFY_PLAYLIST_URI} | awk -F : '{print $3}'`
+  TrackList=$( \
+    curl -s -G  "https://api.spotify.com/v1/playlists/${SPOTIFY_PLAYLIST_ID}/tracks" \
+     -H "Accept: application/json" \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN} " \
+     | jq -r --arg format "$format" '.items[] | [ .track.uri, .track.name, .track.artists[].name, .track.album.name] | @'$format'' \
+     )
+  cecho "$TrackList"
 }
 
 showStatus () {
@@ -143,6 +157,31 @@ showStatus () {
             return nowAt'`;
 
     echo -e $reset"Artist: $(showArtist)\nAlbum: $(showAlbum)\nTrack: $(showTrack) \nPosition: $position / $duration";
+}
+
+getAccessToken() {
+    cecho "Connecting to Spotify's API";
+
+    SPOTIFY_TOKEN_RESPONSE_DATA=$( \
+        curl "${SPOTIFY_TOKEN_URI}" \
+            --silent \
+            -X "POST" \
+            -H "Authorization: Basic ${SHPOTIFY_CREDENTIALS}" \
+            -d "grant_type=client_credentials" \
+    )
+    if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
+        cecho "Autorization failed, please check ${USER_CONFG_FILE}"
+        cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
+        showAPIHelp
+        exit 1
+    fi
+    SPOTIFY_ACCESS_TOKEN=$( \
+        printf "${SPOTIFY_TOKEN_RESPONSE_DATA}" \
+        | command grep -E -o '"access_token":".*",' \
+        | sed 's/"access_token"://g' \
+        | sed 's/"//g' \
+        | sed 's/,.*//g' \
+    )
 }
 
 if [ $# = 0 ]; then
@@ -181,31 +220,6 @@ while [ $# -gt 0 ]; do
                 fi
                 SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
                 SPOTIFY_PLAY_URI="";
-
-                getAccessToken() {
-                    cecho "Connecting to Spotify's API";
-
-                    SPOTIFY_TOKEN_RESPONSE_DATA=$( \
-                        curl "${SPOTIFY_TOKEN_URI}" \
-                            --silent \
-                            -X "POST" \
-                            -H "Authorization: Basic ${SHPOTIFY_CREDENTIALS}" \
-                            -d "grant_type=client_credentials" \
-                    )
-                    if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
-                        cecho "Autorization failed, please check ${USER_CONFG_FILE}"
-                        cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
-                        showAPIHelp
-                        exit 1
-                    fi
-                    SPOTIFY_ACCESS_TOKEN=$( \
-                        printf "${SPOTIFY_TOKEN_RESPONSE_DATA}" \
-                        | command grep -E -o '"access_token":".*",' \
-                        | sed 's/"access_token"://g' \
-                        | sed 's/"//g' \
-                        | sed 's/,.*//g' \
-                    )
-                }
 
                 searchAndPlay() {
                     type="$1"
@@ -397,6 +411,28 @@ while [ $# -gt 0 ]; do
             else
                 # status is the only param
                 showStatus;
+            fi
+            break ;;
+
+        "list" )
+            if [ $# != 1 ]; then
+                # There are additional arguments, a status subcommand
+                case $2 in
+                    "uri" )
+                        array=( $@ );
+                        len=${#array[@]};
+                        SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
+                        SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
+                        getAccessToken;
+                        SPOTIFY_PLAYLIST_URI=${array[@]:2:$len};
+                        if [[ "$3" == "csv" || "$3" == "tsv" || "$3" == "text" || "$3" == "html" ]]; then
+                          format=$3
+                        else
+                          format="csv"
+                        fi
+                        showTrackList;
+                        break ;;
+                esac
             fi
             break ;;
 

--- a/spotify
+++ b/spotify
@@ -95,7 +95,7 @@ showHelp () {
     echo "  toggle shuffle               # Toggles shuffle playback mode.";
     echo "  toggle repeat                # Toggles repeat playback mode.";
     echo;
-    echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist, format in csv|tsv|text|html";
+    echo "  list uri <format> <uri>      # List uri,title,artist and album of specific playlist-uri, format in csv|tsv|text|html";
     showAPIHelp
 }
 
@@ -119,7 +119,7 @@ showTrack() {
 }
 
 showTrackList() {
-  SPOTIFY_PLAYLIST_ID=`echo ${SPOTIFY_PLAYLIST_URI} | awk -F : '{print $3}'`
+  SPOTIFY_PLAYLIST_ID=${SPOTIFY_PLAYLIST_URI##*:}
   TrackList=$( \
     curl -s -G  "https://api.spotify.com/v1/playlists/${SPOTIFY_PLAYLIST_ID}/tracks" \
      -H "Accept: application/json" \


### PR DESCRIPTION
As promised: I've added the option to `like <uri>` and applies to both albums and tracks. Spotify has no API to like artists (for now). 

I've also added a `status liked` option, pointing to function `checkLiked`, which is also used by 'liked <uri>'. It checks if a track or album is already liked. 
This functionality was requested in issue  #69 . Also note that multiple uri's can be liked at once and it can be a mixture of albums and tracks. They are processed one by one. 

I've also rewrote 'list uri' a bit, so it now accepts track, album and playlist uri's, pooping out the following: 
- track: uri, track title, Artist, Album name
- album: uri, album title, Artist, release date
- playlist: all tracks in a playlist by uri, track title, Artist, Album name. 

Let me know what you think :)

