### PR TITLE
Customizable config file path

### DIFF
--- a/spotify
+++ b/spotify
@@ -26,13 +26,13 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-SHPOTIFY_CONFIG_DEFAULTS="CLIENT_ID=\"\"\nCLIENT_SECRET=\"\"";
-SHPOTIFY_CONFIG_FILE=${SHPOTIFY_CONFIG_FILE:-${HOME}/.shpotify.cfg}
-if ! [[ -f "${SHPOTIFY_CONFIG_FILE}" ]]; then
-    touch "${SHPOTIFY_CONFIG_FILE}";
-    echo -e "${SHPOTIFY_CONFIG_DEFAULTS}" > "${SHPOTIFY_CONFIG_FILE}";
+USER_CONFIG_DEFAULTS="CLIENT_ID=\"\"\nCLIENT_SECRET=\"\"";
+USER_CONFIG_FILE=${SHPOTIFY_CONFIG_FILE:-${HOME}/.shpotify.cfg}
+if ! [[ -f "${USER_CONFIG_FILE}" ]]; then
+    touch "${USER_CONFIG_FILE}";
+    echo -e "${USER_CONFIG_DEFAULTS}" > "${USER_CONFIG_FILE}";
 fi
-source "${SHPOTIFY_CONFIG_FILE}";
+source "${USER_CONFIG_FILE}";
 
 # Set the percent change in volume for vol up and vol down
 VOL_INCREMENT=10
@@ -48,7 +48,7 @@ showAPIHelp() {
     echo "  https://developer.spotify.com/my-applications/#!/applications/create";
     echo;
     echo "  Once you've created an application, find the 'Client ID' and 'Client Secret'";
-    echo "  values, and enter them into your shpotify config file at '${SHPOTIFY_CONFIG_FILE}'";
+    echo "  values, and enter them into your shpotify config file at '${USER_CONFIG_FILE}'";
     echo;
     echo "  Be sure to quote your values and don't add any extra spaces!";
     echo "  When done, it should look like this (but with your own values):";
@@ -170,12 +170,12 @@ while [ $# -gt 0 ]; do
                 SPOTIFY_SEARCH_API="https://api.spotify.com/v1/search";
                 SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
                 if [ -z "${CLIENT_ID}" ]; then
-                    cecho "Invalid Client ID, please update ${SHPOTIFY_CONFIG_FILE}";
+                    cecho "Invalid Client ID, please update ${USER_CONFIG_FILE}";
                     showAPIHelp;
                     exit 1;
                 fi
                 if [ -z "${CLIENT_SECRET}" ]; then
-                    cecho "Invalid Client Secret, please update ${SHPOTIFY_CONFIG_FILE}";
+                    cecho "Invalid Client Secret, please update ${USER_CONFIG_FILE}";
                     showAPIHelp;
                     exit 1;
                 fi
@@ -193,7 +193,7 @@ while [ $# -gt 0 ]; do
                             -d "grant_type=client_credentials" \
                     )
                     if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
-                        cecho "Autorization failed, please check ${SHPOTIFY_CONFIG_FILE}"
+                        cecho "Autorization failed, please check ${USER_CONFIG_FILE}"
                         cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
                         showAPIHelp
                         exit 1

--- a/spotify
+++ b/spotify
@@ -26,13 +26,13 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-USER_CONFIG_DEFAULTS="CLIENT_ID=\"\"\nCLIENT_SECRET=\"\"";
-USER_CONFIG_FILE="${HOME}/.shpotify.cfg";
-if ! [[ -f "${USER_CONFIG_FILE}" ]]; then
-    touch "${USER_CONFIG_FILE}";
-    echo -e "${USER_CONFIG_DEFAULTS}" > "${USER_CONFIG_FILE}";
+SHPOTIFY_CONFIG_DEFAULTS="CLIENT_ID=\"\"\nCLIENT_SECRET=\"\"";
+SHPOTIFY_CONFIG_FILE=${SHPOTIFY_CONFIG_FILE:-${HOME}/.shpotify.cfg}
+if ! [[ -f "${SHPOTIFY_CONFIG_FILE}" ]]; then
+    touch "${SHPOTIFY_CONFIG_FILE}";
+    echo -e "${SHPOTIFY_CONFIG_DEFAULTS}" > "${SHPOTIFY_CONFIG_FILE}";
 fi
-source "${USER_CONFIG_FILE}";
+source "${SHPOTIFY_CONFIG_FILE}";
 
 # Set the percent change in volume for vol up and vol down
 VOL_INCREMENT=10
@@ -48,7 +48,7 @@ showAPIHelp() {
     echo "  https://developer.spotify.com/my-applications/#!/applications/create";
     echo;
     echo "  Once you've created an application, find the 'Client ID' and 'Client Secret'";
-    echo "  values, and enter them into your shpotify config file at '${USER_CONFIG_FILE}'";
+    echo "  values, and enter them into your shpotify config file at '${SHPOTIFY_CONFIG_FILE}'";
     echo;
     echo "  Be sure to quote your values and don't add any extra spaces!";
     echo "  When done, it should look like this (but with your own values):";
@@ -170,12 +170,12 @@ while [ $# -gt 0 ]; do
                 SPOTIFY_SEARCH_API="https://api.spotify.com/v1/search";
                 SPOTIFY_TOKEN_URI="https://accounts.spotify.com/api/token";
                 if [ -z "${CLIENT_ID}" ]; then
-                    cecho "Invalid Client ID, please update ${USER_CONFIG_FILE}";
+                    cecho "Invalid Client ID, please update ${SHPOTIFY_CONFIG_FILE}";
                     showAPIHelp;
                     exit 1;
                 fi
                 if [ -z "${CLIENT_SECRET}" ]; then
-                    cecho "Invalid Client Secret, please update ${USER_CONFIG_FILE}";
+                    cecho "Invalid Client Secret, please update ${SHPOTIFY_CONFIG_FILE}";
                     showAPIHelp;
                     exit 1;
                 fi
@@ -193,7 +193,7 @@ while [ $# -gt 0 ]; do
                             -d "grant_type=client_credentials" \
                     )
                     if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
-                        cecho "Autorization failed, please check ${USER_CONFG_FILE}"
+                        cecho "Autorization failed, please check ${SHPOTIFY_CONFIG_FILE}"
                         cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
                         showAPIHelp
                         exit 1


### PR DESCRIPTION
I am using [XDG user directories convention](https://wiki.archlinux.org/index.php/XDG_user_directories) in order to keep my home directory as clean as possible. In that fashion, I want the shpotify config file to be under `~/.config/shpotify/` instead of my home directory. 

Should `SHPOTIFY_CONFIG_FILE` be defined, its value will be used instead of `${HOME}/.shpotify.cfg`