### PR TITLE
fix slow vol set. move user setting to cfg file. message prints optional

### DIFF
--- a/spotify
+++ b/spotify
@@ -26,7 +26,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-USER_CONFIG_DEFAULTS="CLIENT_ID=\"\"\nCLIENT_SECRET=\"\"";
+USER_CONFIG_DEFAULTS="CLIENT_ID=\"\"\nCLIENT_SECRET=\"\"\nVOL_INCREMENT=10\nVERBOSE_MODE=True";
 USER_CONFIG_FILE="${HOME}/.shpotify.cfg";
 if ! [[ -f "${USER_CONFIG_FILE}" ]]; then
     touch "${USER_CONFIG_FILE}";
@@ -35,7 +35,6 @@ fi
 source "${USER_CONFIG_FILE}";
 
 # Set the percent change in volume for vol up and vol down
-VOL_INCREMENT=10
 
 showAPIHelp() {
     echo;
@@ -98,9 +97,20 @@ showHelp () {
 }
 
 cecho(){
-    bold=$(tput bold);
-    green=$(tput setaf 2);
-    reset=$(tput sgr0);
+    local bold=$(tput bold);
+    local green=$(tput setaf 2);
+    local reset=$(tput sgr0);
+    echo $bold$green"$1"$reset;
+}
+
+vecho(){
+	## Verbose Echo. Can turn on-off with VERBOSE_MODE
+	if ! $VERBOSE_MODE ; then
+		return 1
+	fi
+    local bold=$(tput bold);
+    local green=$(tput setaf 2);
+    local reset=$(tput sgr0);
     echo $bold$green"$1"$reset;
 }
 
@@ -118,7 +128,7 @@ showTrack() {
 
 showStatus () {
     state=`osascript -e 'tell application "Spotify" to player state as string'`;
-    cecho "Spotify is currently $state.";
+    vecho "Spotify is currently $state.";
     duration=`osascript -e 'tell application "Spotify"
             set durSec to (duration of current track / 1000) as text
             set tM to (round (durSec / 60) rounding down) as text
@@ -183,7 +193,7 @@ while [ $# -gt 0 ]; do
                 SPOTIFY_PLAY_URI="";
 
                 getAccessToken() {
-                    cecho "Connecting to Spotify's API";
+                    vecho "Connecting to Spotify's API";
 
                     SPOTIFY_TOKEN_RESPONSE_DATA=$( \
                         curl "${SPOTIFY_TOKEN_URI}" \
@@ -213,7 +223,7 @@ while [ $# -gt 0 ]; do
 
                     getAccessToken;
 
-                    cecho "Searching ${type}s for: $Q";
+                    vecho "Searching ${type}s for: $Q";
 
                     SPOTIFY_PLAY_URI=$( \
                         curl -s -G $SPOTIFY_SEARCH_API \
@@ -232,7 +242,7 @@ while [ $# -gt 0 ]; do
 
                         getAccessToken;
 
-                        cecho "Searching playlists for: $Q";
+                        vecho "Searching playlists for: $Q";
 
                         results=$( \
                             curl -s -G $SPOTIFY_SEARCH_API --data-urlencode "q=$Q" -d "type=playlist&limit=10&offset=0" -H "Accept: application/json" -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN}" \
@@ -265,12 +275,13 @@ while [ $# -gt 0 ]; do
 
                 if [ "$SPOTIFY_PLAY_URI" != "" ]; then
                     if [ "$2" = "uri" ]; then
-                        cecho "Playing Spotify URI: $SPOTIFY_PLAY_URI";
+                        vecho "Playing Spotify URI: $SPOTIFY_PLAY_URI";
                     else
                         cecho "Playing ($Q Search) -> Spotify URI: $SPOTIFY_PLAY_URI";
                     fi
 
                     osascript -e "tell application \"Spotify\" to play track \"$SPOTIFY_PLAY_URI\"";
+					showStatus;
 
                 else
                     cecho "No results when searching for $Q";
@@ -279,7 +290,7 @@ while [ $# -gt 0 ]; do
             else
 
                 # play is the only param
-                cecho "Playing Spotify.";
+                vecho "Playing Spotify.";
                 osascript -e 'tell application "Spotify" to play';
             fi
             break ;;
@@ -287,9 +298,9 @@ while [ $# -gt 0 ]; do
         "pause"    )
             state=`osascript -e 'tell application "Spotify" to player state as string'`;
             if [ $state = "playing" ]; then
-              cecho "Pausing Spotify.";
+              vecho "Pausing Spotify.";
             else
-              cecho "Playing Spotify.";
+              vecho "Playing Spotify.";
             fi
 
             osascript -e 'tell application "Spotify" to playpause';
@@ -298,60 +309,66 @@ while [ $# -gt 0 ]; do
         "stop"    )
             state=`osascript -e 'tell application "Spotify" to player state as string'`;
             if [ $state = "playing" ]; then
-              cecho "Pausing Spotify.";
+              vecho "Pausing Spotify.";
               osascript -e 'tell application "Spotify" to playpause';
             else
-              cecho "Spotify is already stopped."
+              vecho "Spotify is already stopped."
             fi
 
             break ;;
 
-        "quit"    ) cecho "Quitting Spotify.";
+        "quit"    ) vecho "Quitting Spotify.";
             osascript -e 'tell application "Spotify" to quit';
             exit 0 ;;
 
-        "next"    ) cecho "Going to next track." ;
+        "next"    ) vecho "Going to next track." ;
             osascript -e 'tell application "Spotify" to next track';
-            showStatus;
+            if ! $VERBOSE_MODE; then
+				showStatus;
+			fi
             break ;;
 
-        "prev"    ) cecho "Going to previous track.";
+        "prev"    ) vecho "Going to previous track.";
             osascript -e '
             tell application "Spotify"
                 set player position to 0
                 previous track
             end tell';
-            showStatus;
+            if ! $VERBOSE_MODE; then
+				showStatus;
+			fi
             break ;;
 
-        "replay"  ) cecho "Replaying current track.";
+        "replay"  ) vecho "Replaying current track.";
             osascript -e 'tell application "Spotify" to set player position to 0'
             break ;;
 
         "vol"    )
-            vol=`osascript -e 'tell application "Spotify" to sound volume as integer'`;
             if [[ $2 = "" || $2 = "show" ]]; then
+            	vol=`osascript -e 'tell application "Spotify" to sound volume as integer'`;
                 cecho "Current Spotify volume level is $vol.";
                 break ;
             elif [ "$2" = "up" ]; then
-              if [ $vol -le $(( 100-$VOL_INCREMENT )) ]; then
+                vol=`osascript -e 'tell application "Spotify" to sound volume as integer'`;
+                if [ $vol -le $(( 100-$VOL_INCREMENT )) ]; then
                     newvol=$(( vol+$VOL_INCREMENT ));
-                    cecho "Increasing Spotify volume to $newvol.";
+                    vecho "Increasing Spotify volume to $newvol.";
                 else
                     newvol=100;
-                    cecho "Spotify volume level is at max.";
+                    vecho "Spotify volume level is at max.";
                 fi
             elif [ "$2" = "down" ]; then
+                vol=`osascript -e 'tell application "Spotify" to sound volume as integer'`;
                 if [ $vol -ge $(( $VOL_INCREMENT )) ]; then
                     newvol=$(( vol-$VOL_INCREMENT ));
-                    cecho "Reducing Spotify volume to $newvol.";
+                    vecho "Reducing Spotify volume to $newvol.";
                 else
                     newvol=0;
-                    cecho "Spotify volume level is at min.";
+                    vecho "Spotify volume level is at min.";
                 fi
             elif [[ $2 =~ ^[0-9]+$ ]] && [[ $2 -ge 0 && $2 -le 100 ]]; then
                 newvol=$2;
-                cecho "Setting Spotify volume level to $newvol";
+                vecho "Setting Spotify volume level to $newvol";
             else
                 echo "Improper use of 'vol' command"
                 echo "The 'vol' command should be used as follows:"
@@ -369,11 +386,11 @@ while [ $# -gt 0 ]; do
             if [ "$2" = "shuffle" ]; then
                 osascript -e 'tell application "Spotify" to set shuffling to not shuffling';
                 curr=`osascript -e 'tell application "Spotify" to shuffling'`;
-                cecho "Spotify shuffling set to $curr";
+                vecho "Spotify shuffling set to $curr";
             elif [ "$2" = "repeat" ]; then
                 osascript -e 'tell application "Spotify" to set repeating to not repeating';
                 curr=`osascript -e 'tell application "Spotify" to repeating'`;
-                cecho "Spotify repeating set to $curr";
+                vecho "Spotify repeating set to $curr";
             fi
             break ;;
 
@@ -437,7 +454,7 @@ while [ $# -gt 0 ]; do
                 set info to info & "\nRepeating:      " & repeating
             end tell
             return info'`
-            cecho "$info";
+            echo "$info";
             break ;;
 
         "share"     )
@@ -462,7 +479,7 @@ while [ $# -gt 0 ]; do
             break ;;
 
         "pos"   )
-            cecho "Adjusting Spotify play position."
+            vecho "Adjusting Spotify play position."
             osascript -e "tell application \"Spotify\" to set player position to $2";
             break ;;
 


### PR DESCRIPTION
Hi there, 

I have added some small features and minor changes. 

- `VOLUME_INCREMENT` variable moved into config file for user configuration.
-  `VERBOSE_MODE` variable added in config file. This bool variable adjust non informative commands to print nothing into screen. like `vol up` and `vol down` `next` etc. 
- all information like echos changed into new `vecho` function to take have control with `VERBOSE_MODE` variable. Function variables is set as local variables.
- `vol` commands adjusted for speed. every osascript calls takes about 0.25 sec. When calling `vol set`,  `vol status` is also called which has no effect on `vol set`. (it just need for `vol up` and `vol down` and `vol`). This makes `vol set` calls slow which takes 0.750 sec total. 

Some minnor suggestion that I thought but did not change in this commit.

- cfg file could create by separate install script. There is no need to check and create cfg file every time the script executed.
- there is no need to check spotify is running or not. Eventually it starts itself. This also slows down the script execution. 
