### PR TITLE
Add XDG Base Directory support

### DIFF
--- a/spotify
+++ b/spotify
@@ -27,7 +27,14 @@
 # SOFTWARE.
 
 USER_CONFIG_DEFAULTS="CLIENT_ID=\"\"\nCLIENT_SECRET=\"\"";
-USER_CONFIG_FILE="${HOME}/.shpotify.cfg";
+
+if [[ -z "${XDG_CONFIG_HOME}" ]]; then
+    USER_CONFIG_FILE="${HOME}/.shpotify.cfg";
+else
+    [ ! -d "${XDG_CONFIG_HOME}/shpotify"/ ] && mkdir -p "${XDG_CONFIG_HOME}/shpotify"
+    USER_CONFIG_FILE="$XDG_CONFIG_HOME/shpotify/shpotify.cfg";
+fi
+
 if ! [[ -f "${USER_CONFIG_FILE}" ]]; then
     touch "${USER_CONFIG_FILE}";
     echo -e "${USER_CONFIG_DEFAULTS}" > "${USER_CONFIG_FILE}";


### PR DESCRIPTION
This PR adds support for XDG Base Directory Specification.

Configuration file should be stored in `$XDG_CONFIG_HOME` if the variable is set.
Otherwise, a dotfile is used in the user `$HOME` directory.

More information here: https://wiki.archlinux.org/title/XDG_Base_Directory