### PR TITLE
Update broken link to Spotify developer dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,4 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-[spotify-dev]: https://developer.spotify.com/my-applications/#!/applications/create
+[spotify-dev]: https://developer.spotify.com/dashboard/create


### PR DESCRIPTION
The previous link to the Spotify developer dashboard to new create application was broken. This PR updates the link to the new URL.
